### PR TITLE
Load from local storage if any is stored

### DIFF
--- a/src/activities/hoc2019/PondCreator.jsx
+++ b/src/activities/hoc2019/PondCreator.jsx
@@ -82,6 +82,12 @@ export default class PondCreator extends React.Component {
     localStorage.setItem(SESSION_KEY, this.state.trainer.getDatasetJSON());
   };
 
+  startOver() {
+    this.state.trainer.clearAll();
+    localStorage.removeItem(SESSION_KEY);
+    this.setMode(Modes.Training);
+  }
+
   render() {
     if (!this.state.initialized) {
       return null;
@@ -111,6 +117,7 @@ export default class PondCreator extends React.Component {
             </Button>
           </div>
         )}
+        <Button onClick={() => this.clearTraining()}>Start over</Button>
       </div>
     );
   }

--- a/src/activities/hoc2019/PondCreator.jsx
+++ b/src/activities/hoc2019/PondCreator.jsx
@@ -6,6 +6,7 @@ import Predict from './Predict';
 import {generateRandomFish} from './SpritesheetFish';
 
 const FISH_COUNT = 9;
+const SESSION_KEY = 'PondCreator';
 
 export const ClassType = Object.freeze({
   Like: 0,
@@ -23,6 +24,7 @@ export default class PondCreator extends React.Component {
 
     const trainer = new SimpleTrainer();
     trainer.initializeClassifiers().then(() => {
+      this.loadTraining();
       this.setState({initialized: true});
     });
     this.state = {
@@ -69,6 +71,17 @@ export default class PondCreator extends React.Component {
     }
   };
 
+  loadTraining() {
+    const storedTraining = localStorage.getItem(SESSION_KEY);
+    if (storedTraining) {
+      this.state.trainer.loadDatasetJSON(storedTraining);
+    }
+  }
+
+  saveTraining = () => {
+    localStorage.setItem(SESSION_KEY, this.state.trainer.getDatasetJSON());
+  };
+
   render() {
     if (!this.state.initialized) {
       return null;
@@ -83,6 +96,7 @@ export default class PondCreator extends React.Component {
               rows={2}
               cols={2}
               label={'Like'}
+              saveTraining={this.saveTraining}
             />
             <Button onClick={() => this.setMode(Modes.Predicting)}>
               Train Bot

--- a/src/activities/hoc2019/Training.jsx
+++ b/src/activities/hoc2019/Training.jsx
@@ -10,7 +10,8 @@ export default class Training extends React.Component {
     trainer: PropTypes.object.isRequired,
     rows: PropTypes.number.isRequired,
     cols: PropTypes.number.isRequired,
-    label: PropTypes.string.isRequired
+    label: PropTypes.string.isRequired,
+    saveTraining: PropTypes.func
   };
 
   constructor(props) {
@@ -56,6 +57,9 @@ export default class Training extends React.Component {
         }
       });
     });
+    if (this.props.saveTraining) {
+      this.props.saveTraining();
+    }
   }
 
   render() {


### PR DESCRIPTION
PondCreator defines functions to store to local storage to persist across refreshes and browser sessions. Builds on the work from #31.

Only visible change is that I also added a "Start over" button as refreshing the page doesn't cut it anymore.

