### PR TITLE
Create a cache of canvases

### DIFF
--- a/src/demo/canvasCache.js
+++ b/src/demo/canvasCache.js
@@ -1,4 +1,4 @@
-const CACHE_SIZE = 20;
+const CACHE_SIZE = 30;
 
 export default class CanvasCache {
   constructor() {
@@ -11,14 +11,30 @@ export default class CanvasCache {
     }
   }
 
+  /*
+   * Takes a cache key and returns an array of [canvas, hit]
+   * canvas is a canvas reserved for the caller.
+   * hit indicates whether there was a cache hit
+   * The caller should not make assumptions about the state of the canvas if
+   * there was not a cache hit.
+   */
   getCanvas(key) {
     const canvasObjectIdx = this.canvases.findIndex(elem => elem.key === key);
-    const canvasObject = this.canvases.splice(canvasObjectIdx !== -1 ? canvasObjectIdx : this.canvases.length - 1, 1)[0];
-    canvasObject.key = key;
-
-    const ctx = canvasObject.canvas.getContext('2d');
-    ctx.clearRect(0, 0, canvasObject.canvas.width, canvasObject.canvas.height);
-    this.canvases.unshift(canvasObject)
-    return canvasObject.canvas;
+    const canvasObject = this.canvases.splice(
+      canvasObjectIdx !== -1 ? canvasObjectIdx : this.canvases.length - 1,
+      1
+    )[0];
+    if (canvasObject.key !== key) {
+      canvasObject.key = key;
+      const ctx = canvasObject.canvas.getContext('2d');
+      ctx.clearRect(
+        0,
+        0,
+        canvasObject.canvas.width,
+        canvasObject.canvas.height
+      );
+    }
+    this.canvases.unshift(canvasObject);
+    return [canvasObject.canvas, canvasObjectIdx !== -1];
   }
 }

--- a/src/demo/canvasCache.js
+++ b/src/demo/canvasCache.js
@@ -1,6 +1,11 @@
 const CACHE_SIZE = 30;
 
 export default class CanvasCache {
+  /*
+   * Instantiates this.canvases that holds CACHE_SIZE canvases. this.canvases
+   * is ordered by most recent use, with the canvas at spot 0 being *most*
+   * recently used.
+   */
   constructor() {
     this.canvases = [];
     for (var i = 0; i < CACHE_SIZE; ++i) {
@@ -19,12 +24,15 @@ export default class CanvasCache {
    * there was not a cache hit.
    */
   getCanvas(key) {
-    const canvasObjectIdx = this.canvases.findIndex(elem => elem.key === key);
-    const canvasObject = this.canvases.splice(
-      canvasObjectIdx !== -1 ? canvasObjectIdx : this.canvases.length - 1,
-      1
-    )[0];
+    var canvasObjectIdx = this.canvases.findIndex(elem => elem.key === key);
+    // If the key isn't in the cache then we want to grab the last element.
+    if (canvasObjectIdx === -1) {
+      canvasObjectIdx = this.canvases.length - 1;
+    }
+    const canvasObject = this.canvases.splice(canvasObjectIdx, 1)[0];
+    var cacheHit = true;
     if (canvasObject.key !== key) {
+      cacheHit = false;
       canvasObject.key = key;
       const ctx = canvasObject.canvas.getContext('2d');
       ctx.clearRect(
@@ -34,7 +42,8 @@ export default class CanvasCache {
         canvasObject.canvas.height
       );
     }
+    // Add this canvas to the front of the array (most recently used)
     this.canvases.unshift(canvasObject);
-    return [canvasObject.canvas, canvasObjectIdx !== -1];
+    return [canvasObject.canvas, cacheHit];
   }
 }

--- a/src/demo/canvasCache.js
+++ b/src/demo/canvasCache.js
@@ -1,0 +1,24 @@
+const CACHE_SIZE = 20;
+
+export default class CanvasCache {
+  constructor() {
+    this.canvases = [];
+    for (var i = 0; i < CACHE_SIZE; ++i) {
+      this.canvases.push({
+        key: null,
+        canvas: document.createElement('canvas')
+      });
+    }
+  }
+
+  getCanvas(key) {
+    const canvasObjectIdx = this.canvases.findIndex(elem => elem.key === key);
+    const canvasObject = this.canvases.splice(canvasObjectIdx !== -1 ? canvasObjectIdx : this.canvases.length - 1, 1)[0];
+    canvasObject.key = key;
+
+    const ctx = canvasObject.canvas.getContext('2d');
+    ctx.clearRect(0, 0, canvasObject.canvas.width, canvasObject.canvas.height);
+    this.canvases.unshift(canvasObject)
+    return canvasObject.canvas;
+  }
+}

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -2,6 +2,7 @@ import 'babel-polyfill';
 import _ from 'lodash';
 import {getState} from './state';
 import constants, {Modes} from './constants';
+import CanvasCache from './canvasCache';
 import {
   backgroundPathForMode,
   bodyAnchorFromType,
@@ -19,6 +20,8 @@ var $time =
 let prevState = {};
 
 let currentModeStartTime = $time();
+
+const canvasCache = new CanvasCache();
 
 export const render = () => {
   const state = getState();
@@ -188,7 +191,7 @@ const loadFishImage = fishPart => {
 
 const drawSingleFish = (fish, fishXPos, fishYPos, ctx) => {
   if (!fish.canvas) {
-    fish.canvas = document.createElement('canvas');
+    fish.canvas = canvasCache.getCanvas(fish.id);
     fish.canvas.width = constants.fishCanvasWidth;
     fish.canvas.height = constants.fishCanvasHeight;
     loadFishImages(fish).then(results => {
@@ -216,11 +219,12 @@ const drawFish = (fish, results, ctx, x = 0, y = 0) => {
   const bodyAnchor = bodyAnchorFromType(body, body.type);
   results = _.orderBy(results, ['fishPart.type']);
 
+  const intermediateCanvas = canvasCache.getCanvas(`interediate-${fish.id}`);
   results.forEach(result => {
-    let intermediateCanvas = document.createElement('canvas');
     intermediateCanvas.width = constants.fishCanvasWidth;
     intermediateCanvas.height = constants.fishCanvasHeight;
     let intermediateCtx = intermediateCanvas.getContext('2d');
+    intermediateCtx.clearRect(0,0,constants.fishCanvasWidth, constants.fishCanvasHeight);
     let anchor = [0, 0];
     if (result.fishPart.type !== FishBodyPart.BODY) {
       const bodyAnchor = bodyAnchorFromType(body, result.fishPart.type);

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -190,12 +190,12 @@ const loadFishImage = fishPart => {
 };
 
 const drawSingleFish = (fish, fishXPos, fishYPos, ctx) => {
-  if (!fish.canvas) {
-    fish.canvas = canvasCache.getCanvas(fish.id);
-    fish.canvas.width = constants.fishCanvasWidth;
-    fish.canvas.height = constants.fishCanvasHeight;
+  const [fishCanvas, hit] = canvasCache.getCanvas(fish.id);
+  if (!hit) {
+    fishCanvas.width = constants.fishCanvasWidth;
+    fishCanvas.height = constants.fishCanvasHeight;
     loadFishImages(fish).then(results => {
-      const fishCtx = fish.canvas.getContext('2d');
+      const fishCtx = fishCanvas.getContext('2d');
       drawFish(
         fish,
         results,
@@ -203,10 +203,10 @@ const drawSingleFish = (fish, fishXPos, fishYPos, ctx) => {
         constants.fishCanvasWidth / 2,
         constants.fishCanvasHeight / 2
       );
-      ctx.drawImage(fish.canvas, fishXPos, fishYPos);
+      ctx.drawImage(fishCanvas, fishXPos, fishYPos);
     });
   } else {
-    ctx.drawImage(fish.canvas, fishXPos, fishYPos);
+    ctx.drawImage(fishCanvas, fishXPos, fishYPos);
   }
 };
 
@@ -219,12 +219,17 @@ const drawFish = (fish, results, ctx, x = 0, y = 0) => {
   const bodyAnchor = bodyAnchorFromType(body, body.type);
   results = _.orderBy(results, ['fishPart.type']);
 
-  const intermediateCanvas = canvasCache.getCanvas(`interediate-${fish.id}`);
+  const intermediateCanvas = canvasCache.getCanvas(`interediate-${fish.id}`)[0];
+  const intermediateCtx = intermediateCanvas.getContext('2d');
+  intermediateCanvas.width = constants.fishCanvasWidth;
+  intermediateCanvas.height = constants.fishCanvasHeight;
   results.forEach(result => {
-    intermediateCanvas.width = constants.fishCanvasWidth;
-    intermediateCanvas.height = constants.fishCanvasHeight;
-    let intermediateCtx = intermediateCanvas.getContext('2d');
-    intermediateCtx.clearRect(0,0,constants.fishCanvasWidth, constants.fishCanvasHeight);
+    intermediateCtx.clearRect(
+      0,
+      0,
+      constants.fishCanvasWidth,
+      constants.fishCanvasHeight
+    );
     let anchor = [0, 0];
     if (result.fishPart.type !== FishBodyPart.BODY) {
       const bodyAnchor = bodyAnchorFromType(body, result.fishPart.type);


### PR DESCRIPTION
This currently uses a _super_ simple cache of canvases that just reuses the least recently used canvas. I struggled a bit with what the interface with this should be.

`getCanvas` takes in a key that is the cache key and returns the canvas as well as whether there was a cache hit. If there was, it means the caller can assume that the state of the cache is the same as the least time it was used. If it was a miss, the caller can't assume anything about the canvas. Currently `canvasCache` clears the canvas but it doesn't have to.

If you want to know if this works though, this cache is a size of 20 and repeated likes/dislikes resulted in a ceiling of 24 canvases in memory (one is the background, not sure what the other 3 are). The code currently checked into master creates 8 canvases on every like/dislike and does not garbage collect them.