### PR TITLE
Preload all fish part images once

### DIFF
--- a/src/demo/constants.js
+++ b/src/demo/constants.js
@@ -8,9 +8,10 @@ const constants = {
 export default constants;
 
 export const Modes = Object.freeze({
-  Training: 0,
-  Predicting: 1,
-  Pond: 2
+  Loading: 0,
+  Training: 2,
+  Predicting: 3,
+  Pond: 4
 });
 
 export const ClassType = Object.freeze({

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -20,5 +20,7 @@ $(document).ready(() => {
 
   initScene();
 
+  // Start the renderer.  It will self-perpetute by calling
+  // requestAnimationFrame on itself.
   render();
 });

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import constants, {Modes} from './constants';
 import {setState} from './state';
 import {init as initScene} from './init';
-import {initRenderer, render} from './renderer';
+import {render} from './renderer';
 
 $(document).ready(() => {
   // Set up initial state

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import constants, {Modes} from './constants';
 import {setState} from './state';
 import {init as initScene} from './init';
+import {initRenderer, render} from './renderer';
 
 $(document).ready(() => {
   // Set up initial state
@@ -11,11 +12,13 @@ $(document).ready(() => {
   canvas.height = backgroundCanvas.height = constants.canvasHeight;
 
   setState({
-    currentMode: Modes.Training,
+    currentMode: Modes.Loading,
     canvas,
     backgroundCanvas,
     uiContainer: document.getElementById('ui-container')
   });
 
   initScene();
+
+  render();
 });

--- a/src/demo/init.js
+++ b/src/demo/init.js
@@ -1,9 +1,7 @@
 import {init as initModel} from './models';
-import {render} from './renderer';
 import {getState} from './state';
 
 export const init = () => {
   const state = getState();
   initModel(state);
-  render();
 };

--- a/src/demo/models/index.js
+++ b/src/demo/models/index.js
@@ -1,3 +1,4 @@
+import {init as initLoading} from './loading';
 import {init as initTraining} from './train';
 import {init as initPredicting} from './predict';
 import {init as initPond} from './pond';
@@ -7,6 +8,9 @@ import {Modes} from '../constants';
 // Should only be called when mode changes.
 export const init = state => {
   switch (state.currentMode) {
+    case Modes.Loading:
+      initLoading();
+      break;
     case Modes.Training:
       initTraining();
       break;

--- a/src/demo/models/loading.js
+++ b/src/demo/models/loading.js
@@ -1,0 +1,11 @@
+import 'babel-polyfill';
+import {initRenderer} from '../renderer';
+import {setState} from '../state';
+import {Modes} from '../constants';
+import {init as initScene} from '../init';
+
+export const init = async () => {
+  await initRenderer();
+  setState({currentMode: Modes.Training});
+  initScene();
+};

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -221,10 +221,8 @@ const drawSingleFish = (fish, fishXPos, fishYPos, ctx) => {
       constants.fishCanvasWidth / 2,
       constants.fishCanvasHeight / 2
     );
-    ctx.drawImage(fishCanvas, fishXPos, fishYPos);
-  } else {
-    ctx.drawImage(fishCanvas, fishXPos, fishYPos);
   }
+  ctx.drawImage(fishCanvas, fishXPos, fishYPos);
 };
 
 // Renders a fish into a canvas from its constituent parts.

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -157,16 +157,14 @@ const loadAllFishPartImages = () => {
   Object.keys(fishData)
     .filter(partName => partName !== 'colorPalettes')
     .forEach((partName, partIndex) => {
-      Object.keys(fishData[partName]).forEach(
-        (variationName, variationIndex) => {
-          const partData = {
-            partIndex: fishData[partName][variationName].type,
-            variationIndex: fishData[partName][variationName].index,
-            src: fishData[partName][variationName].src
-          };
-          fishPartImagesToLoad.push(partData);
-        }
-      );
+      Object.keys(fishData[partName]).forEach(variationName => {
+        const partData = {
+          partIndex: fishData[partName][variationName].type,
+          variationIndex: fishData[partName][variationName].index,
+          src: fishData[partName][variationName].src
+        };
+        fishPartImagesToLoad.push(partData);
+      });
     });
 
   return Promise.all(fishPartImagesToLoad.map(loadFishPartImage)).then(
@@ -233,7 +231,9 @@ const renderFishFromParts = (fish, ctx, x = 0, y = 0) => {
   const bodyAnchor = bodyAnchorFromType(body, body.type);
   const parts = _.orderBy(fish.parts, ['type']);
 
-  const intermediateCanvas = canvasCache.getCanvas(`intermediate-${fish.id}`)[0];
+  const intermediateCanvas = canvasCache.getCanvas(
+    `intermediate-${fish.id}`
+  )[0];
   const intermediateCtx = intermediateCanvas.getContext('2d');
   intermediateCanvas.width = constants.fishCanvasWidth;
   intermediateCanvas.height = constants.fishCanvasHeight;

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -8,7 +8,7 @@ import {
   colorFromType,
   randomInt
 } from './helpers';
-import {FishBodyPart} from '../utils/fishData';
+import fishData, {FishBodyPart} from '../utils/fishData';
 
 var $time =
   Date.now ||
@@ -20,6 +20,14 @@ let prevState = {};
 
 let currentModeStartTime = $time();
 
+let fishPartImages = {};
+
+export const initRenderer = () => {
+  return loadAllFishPartImages();
+};
+
+// Render a single frame of the scene.
+// Sometimes performs special rendering actions, such as when mode has changed.
 export const render = () => {
   const state = getState();
 
@@ -33,6 +41,9 @@ export const render = () => {
   }
 
   switch (state.currentMode) {
+    case Modes.Loading:
+      clearCanvas(state.canvas);
+      break;
     case Modes.Training:
       clearCanvas(state.canvas);
       drawTrainingFish(state);
@@ -44,7 +55,6 @@ export const render = () => {
       break;
     case Modes.Pond:
       if (prevState.pondFish !== state.pondFish) {
-        loadPondFishImages();
         clearCanvas(state.canvas);
       }
       clearCanvas(state.canvas);
@@ -60,6 +70,7 @@ export const render = () => {
   window.requestAnimFrame(render);
 };
 
+// Load and display the background image onto the background canvas.
 export const drawBackground = state => {
   const canvas = state.backgroundCanvas;
   if (!canvas) {
@@ -76,6 +87,8 @@ export const drawBackground = state => {
   }
 };
 
+// Load a single image.
+// Used by drawBackground.
 const loadImage = imgPath => {
   return new Promise((resolve, reject) => {
     const img = new Image();
@@ -87,6 +100,7 @@ const loadImage = imgPath => {
   });
 };
 
+// Draw the fish for training mode.
 export const drawTrainingFish = state => {
   const canvas = state.canvas;
   const ctx = canvas.getContext('2d');
@@ -104,6 +118,7 @@ export const drawTrainingFish = state => {
   drawSingleFish(fish, fishXPos, fishYPos, ctx);
 };
 
+// Draw the upcoming fish for training mode.
 export const drawUpcomingFish = state => {
   const fishLeft = state.fishData.length - state.trainingIndex - 1;
   const numUpcomingFish = fishLeft >= 3 ? 3 : fishLeft;
@@ -119,12 +134,7 @@ export const drawUpcomingFish = state => {
   }
 };
 
-export const drawUiElements = state => {
-  const container = state.uiContainer;
-  container.innerHTML = '';
-  state.uiElements.forEach(el => container.appendChild(el));
-};
-
+// Draw the fish for predicting mode.
 export const drawPredictingFish = state => {
   const fish = state.fishData[state.trainingIndex];
   const canvas = state.canvas;
@@ -136,29 +146,43 @@ export const drawPredictingFish = state => {
   );
 };
 
-export const drawPondFish = state => {
-  const canvas = state.canvas;
-  state.pondFish.forEach(fish => {
-    loadFishImages(fish).then(results => {
-      const randomX = randomInt(
-        constants.fishCanvasWidth / 4,
-        canvas.width - constants.fishCanvasWidth / 4
-      );
-      const randomY = randomInt(
-        constants.fishCanvasHeight / 4,
-        canvas.height - constants.fishCanvasHeight / 4
-      );
-      drawFish(fish, results, canvas.getContext('2d'), randomX, randomY);
+// Load all fish part images, and store them in fishPartImages.
+const loadAllFishPartImages = () => {
+  let fishPartImagesToLoad = [];
+  Object.keys(fishData).filter(partName => partName !=='colorPalettes').forEach((partName, partIndex) => {
+    Object.keys(fishData[partName]).forEach((variationName, variationIndex) => {
+      const partData = {
+        partIndex: fishData[partName][variationName].type,
+        variationIndex: fishData[partName][variationName].index,
+        src: fishData[partName][variationName].src
+      };
+      fishPartImagesToLoad.push(partData);
+    });
+  });
+
+  return Promise.all(fishPartImagesToLoad.map(loadFishPartImage)).then(results => {
+    results.forEach(result => {
+      if (fishPartImages[result.data.partIndex] === undefined) {
+        fishPartImages[result.data.partIndex] = {};
+      }
+      fishPartImages[result.data.partIndex][result.data.variationIndex] = result.img;
     });
   });
 };
 
-const loadPondFishImages = () => {
-  getState().pondFish.forEach(fish => {
-    fish.parts.map(loadFishImage);
+// Load a single fish part image.
+const loadFishPartImage = data => {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.addEventListener('load', e => resolve({img, data}));
+    img.addEventListener('error', () => {
+      reject(new Error(`failed to load image at ${data.src}`));
+    });
+    img.src = data.src;
   });
 };
 
+// Draw the fish for pond mode.
 const drawPondFishImages = () => {
   const canvas = getState().canvas;
   const ctx = canvas.getContext('2d');
@@ -171,78 +195,67 @@ const drawPondFishImages = () => {
   });
 };
 
-const loadFishImages = fish => {
-  return Promise.all(fish.parts.map(loadFishImage));
-};
-
-const loadFishImage = fishPart => {
-  return new Promise((resolve, reject) => {
-    const img = new Image();
-    img.addEventListener('load', e => resolve({img, fishPart}));
-    img.addEventListener('error', () => {
-      reject(new Error(`failed to load image at #{fishPart.src}`));
-    });
-    img.src = fishPart.src;
-  });
-};
-
+// Draw a single fish, preferably from cached canvas.
+// Used by drawTrainingFish, drawUpcomingFish, drawPredictingFish.
 const drawSingleFish = (fish, fishXPos, fishYPos, ctx) => {
   if (!fish.canvas) {
     fish.canvas = document.createElement('canvas');
     fish.canvas.width = constants.fishCanvasWidth;
     fish.canvas.height = constants.fishCanvasHeight;
-    loadFishImages(fish).then(results => {
-      const fishCtx = fish.canvas.getContext('2d');
-      drawFish(
-        fish,
-        results,
-        fishCtx,
-        constants.fishCanvasWidth / 2,
-        constants.fishCanvasHeight / 2
-      );
-      ctx.drawImage(fish.canvas, fishXPos, fishYPos);
-    });
+    const fishCtx = fish.canvas.getContext('2d');
+    renderFishFromParts(
+      fish,
+      fishCtx,
+      constants.fishCanvasWidth / 2,
+      constants.fishCanvasHeight / 2
+    );
+    ctx.drawImage(fish.canvas, fishXPos, fishYPos);
   } else {
     ctx.drawImage(fish.canvas, fishXPos, fishYPos);
   }
 };
 
-const drawFish = (fish, results, ctx, x = 0, y = 0) => {
+// Renders a fish into a canvas from its constituent parts.
+const renderFishFromParts = (fish, ctx, x = 0, y = 0) => {
   ctx.translate(constants.fishCanvasWidth, 0);
   ctx.scale(-1, 1);
-  const body = results.find(
-    result => result.fishPart.type === FishBodyPart.BODY
-  ).fishPart;
+  const body = fish.parts.find(
+    part => part.type === FishBodyPart.BODY
+  );
   const bodyAnchor = bodyAnchorFromType(body, body.type);
-  results = _.orderBy(results, ['fishPart.type']);
+  const parts = _.orderBy(fish.parts, ['type']);
 
-  results.forEach(result => {
+  parts.forEach((part, partIndex) => {
     let intermediateCanvas = document.createElement('canvas');
     intermediateCanvas.width = constants.fishCanvasWidth;
     intermediateCanvas.height = constants.fishCanvasHeight;
     let intermediateCtx = intermediateCanvas.getContext('2d');
     let anchor = [0, 0];
-    if (result.fishPart.type !== FishBodyPart.BODY) {
-      const bodyAnchor = bodyAnchorFromType(body, result.fishPart.type);
+    if (part.type !== FishBodyPart.BODY) {
+      const bodyAnchor = bodyAnchorFromType(body, part.type);
       anchor[0] = bodyAnchor[0];
       anchor[1] = bodyAnchor[1];
     }
-    if (result.fishPart.type === FishBodyPart.TAIL) {
-      anchor[1] -= result.img.height / 2;
+
+    const img = fishPartImages[part.type][part.index]; //fishPartImages[part.type][part.variant];
+
+    if (part.type === FishBodyPart.TAIL) {
+      anchor[1] -= img.height / 2;
     }
 
     const xPos = bodyAnchor[0] + anchor[0];
     const yPos = bodyAnchor[1] + anchor[1];
 
-    intermediateCtx.drawImage(result.img, xPos, yPos);
-    const rgb = colorFromType(fish.colorPalette, result.fishPart.type);
+
+    intermediateCtx.drawImage(img, xPos, yPos);
+    const rgb = colorFromType(fish.colorPalette, part.type);
 
     if (rgb) {
       let imageData = intermediateCtx.getImageData(
         xPos,
         yPos,
-        result.img.width,
-        result.img.height
+        img.width,
+        img.height
       );
       let data = imageData.data;
 
@@ -267,12 +280,13 @@ const drawFish = (fish, results, ctx, x = 0, y = 0) => {
   });
 };
 
+// Clear the sprite canvas.
 export const clearCanvas = canvas => {
   canvas.getContext('2d').clearRect(0, 0, canvas.width, canvas.height);
 };
 
+// Draw an overlay over the whole scene.  Used for fades.
 function drawOverlays() {
-  // update fade
   var duration = $time() - currentModeStartTime;
   var amount = 1 - duration / 800;
   if (amount < 0) {
@@ -281,6 +295,7 @@ function drawOverlays() {
   DrawFade(amount, '#000');
 }
 
+// Draw a fade over the scene.
 function DrawFade(amount, overlayColour) {
   if (amount === 0) {
     return;
@@ -293,6 +308,7 @@ function DrawFade(amount, overlayColour) {
   canvasCtx.globalAlpha = 1;
 }
 
+// Draw a filled rectangle.
 function DrawFilledRect(x, y, w, h) {
   x = Math.floor(x / 1);
   y = Math.floor(y / 1);
@@ -303,6 +319,14 @@ function DrawFilledRect(x, y, w, h) {
   canvasCtx.fillRect(x, y, w, h);
 }
 
+// Attach HTML UI elements to the DOM.
+export const drawUiElements = state => {
+  const container = state.uiContainer;
+  container.innerHTML = '';
+  state.uiElements.forEach(el => container.appendChild(el));
+};
+
+// A single frame of animation.
 window.requestAnimFrame = (() => {
   return (
     window.requestAnimationFrame ||

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -6,8 +6,7 @@ import CanvasCache from './canvasCache';
 import {
   backgroundPathForMode,
   bodyAnchorFromType,
-  colorFromType,
-  randomInt
+  colorFromType
 } from './helpers';
 import fishData, {FishBodyPart} from '../utils/fishData';
 

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -149,25 +149,32 @@ export const drawPredictingFish = state => {
 // Load all fish part images, and store them in fishPartImages.
 const loadAllFishPartImages = () => {
   let fishPartImagesToLoad = [];
-  Object.keys(fishData).filter(partName => partName !=='colorPalettes').forEach((partName, partIndex) => {
-    Object.keys(fishData[partName]).forEach((variationName, variationIndex) => {
-      const partData = {
-        partIndex: fishData[partName][variationName].type,
-        variationIndex: fishData[partName][variationName].index,
-        src: fishData[partName][variationName].src
-      };
-      fishPartImagesToLoad.push(partData);
+  Object.keys(fishData)
+    .filter(partName => partName !== 'colorPalettes')
+    .forEach((partName, partIndex) => {
+      Object.keys(fishData[partName]).forEach(
+        (variationName, variationIndex) => {
+          const partData = {
+            partIndex: fishData[partName][variationName].type,
+            variationIndex: fishData[partName][variationName].index,
+            src: fishData[partName][variationName].src
+          };
+          fishPartImagesToLoad.push(partData);
+        }
+      );
     });
-  });
 
-  return Promise.all(fishPartImagesToLoad.map(loadFishPartImage)).then(results => {
-    results.forEach(result => {
-      if (fishPartImages[result.data.partIndex] === undefined) {
-        fishPartImages[result.data.partIndex] = {};
-      }
-      fishPartImages[result.data.partIndex][result.data.variationIndex] = result.img;
-    });
-  });
+  return Promise.all(fishPartImagesToLoad.map(loadFishPartImage)).then(
+    results => {
+      results.forEach(result => {
+        if (fishPartImages[result.data.partIndex] === undefined) {
+          fishPartImages[result.data.partIndex] = {};
+        }
+        fishPartImages[result.data.partIndex][result.data.variationIndex] =
+          result.img;
+      });
+    }
+  );
 };
 
 // Load a single fish part image.
@@ -219,9 +226,7 @@ const drawSingleFish = (fish, fishXPos, fishYPos, ctx) => {
 const renderFishFromParts = (fish, ctx, x = 0, y = 0) => {
   ctx.translate(constants.fishCanvasWidth, 0);
   ctx.scale(-1, 1);
-  const body = fish.parts.find(
-    part => part.type === FishBodyPart.BODY
-  );
+  const body = fish.parts.find(part => part.type === FishBodyPart.BODY);
   const bodyAnchor = bodyAnchorFromType(body, body.type);
   const parts = _.orderBy(fish.parts, ['type']);
 
@@ -245,7 +250,6 @@ const renderFishFromParts = (fish, ctx, x = 0, y = 0) => {
 
     const xPos = bodyAnchor[0] + anchor[0];
     const yPos = bodyAnchor[1] + anchor[1];
-
 
     intermediateCtx.drawImage(img, xPos, yPos);
     const rgb = colorFromType(fish.colorPalette, part.type);

--- a/src/utils/fishData.js
+++ b/src/utils/fishData.js
@@ -17,10 +17,11 @@ export const FishBodyPart = Object.freeze({
   EYE: 6
 });
 
-const fish = {
+const fishData = {
   // BODY KNN DATA: [height:width ratio]
   bodies: {
     brushTip: {
+      index: 0,
       src: 'images/fish/body/Body_BrushTip.png',
       anchor: [100, 50],
       eyeAnchor: [17, 12],
@@ -33,6 +34,7 @@ const fish = {
       type: FishBodyPart.BODY
     },
     eel: {
+      index: 1,
       src: 'images/fish/body/Body_Eel.png',
       anchor: [100, 50],
       eyeAnchor: [17, 15],
@@ -45,7 +47,7 @@ const fish = {
       type: FishBodyPart.BODY
     },
     /*
-    // This image needs to be fixed to get rid of the whitetspace
+    // This image needs to be fixed to get rid of the whitespace
     eyeShape: {
       src: 'images/fish/body/Body_EyeShape.png',
       anchor: [100, 50],
@@ -58,6 +60,7 @@ const fish = {
       type: FishBodyPart.BODY
     },*/
     round: {
+      index: 2,
       src: 'images/fish/body/Body_Round.png',
       anchor: [100, 50],
       eyeAnchor: [10, 15],
@@ -70,6 +73,7 @@ const fish = {
       type: FishBodyPart.BODY
     },
     roundedSquare: {
+      index: 3,
       src: 'images/fish/body/Body_RoundedSquare.png',
       anchor: [100, 50],
       eyeAnchor: [15, 12],
@@ -82,6 +86,7 @@ const fish = {
       type: FishBodyPart.BODY
     },
     shark: {
+      index: 4,
       src: 'images/fish/body/Body_Shark.png',
       anchor: [80, 50],
       eyeAnchor: [18, 12],
@@ -97,26 +102,31 @@ const fish = {
   // EYE KNN DATA: [eye area, pupil:eye area ratio]
   eyes: {
     angry: {
+      index: 0,
       src: 'images/fish/eyes/Eyes_Angry.png',
       knnData: [1, 0.0],
       type: FishBodyPart.EYE
     },
     big: {
+      index: 1,
       src: 'images/fish/eyes/Eyes_Big.png',
       knnData: [1, 0.75],
       type: FishBodyPart.EYE
     },
     concentric: {
+      index: 2,
       src: 'images/fish/eyes/Eyes_Concentric.png',
       knnData: [1, 1.00],
       type: FishBodyPart.EYE
     },
     side: {
+      index: 3,
       src: 'images/fish/eyes/Eyes_Side.png',
       knnData: [1, 0.5],
       type: FishBodyPart.EYE
     },
     unibrow: {
+      index: 4,
       src: 'images/fish/eyes/Eyes_Unibrow.png',
       knnData: [1, 0.25],
       type: FishBodyPart.EYE
@@ -125,46 +135,55 @@ const fish = {
   // MOUTH KNN DATA: [hasTeeth (0/1 bool), ratio of height:wifth]
   mouths: {
     curvedCylinder: {
+      index: 0,
       src: 'images/fish/mouth/Mouth_CurvedCylinder.png',
       knnData: [0, 0.5],
       type: FishBodyPart.MOUTH
     },
     duckLips: {
+      index: 1,
       src: 'images/fish/mouth/Mouth_DuckLips.png',
       knnData: [0, 0.375],
       type: FishBodyPart.MOUTH
     },
     heart: {
+      index: 2,
       src: 'images/fish/mouth/Mouth_Heart.png',
       knnData: [0, 0.75],
       type: FishBodyPart.MOUTH
     },
     lips: {
+      index: 3,
       src: 'images/fish/mouth/Mouth_Lips.png',
       knnData: [0, 1.0],
       type: FishBodyPart.MOUTH
     },
     longMouth: {
+      index: 4,
       src: 'images/fish/mouth/Mouth_LongMouth.png',
       knnData: [0, 0.875],
       type: FishBodyPart.MOUTH
     },
     oval: {
+      index: 5,
       src: 'images/fish/mouth/Mouth_Oval.png',
       knnData: [0, 0.25],
       type: FishBodyPart.MOUTH
     },
     roundedHeart: {
+      index: 6,
       src: 'images/fish/mouth/Mouth_RoundedHeart.png',
       knnData: [0, 0.625],
       type: FishBodyPart.MOUTH
     },
     shark: {
+      index: 7,
       src: 'images/fish/mouth/Mouth_Shark.png',
       knnData: [1, 0.00],
       type: FishBodyPart.MOUTH
     },
     sharpTeeth: {
+      index: 8,
       src: 'images/fish/mouth/Mouth_SharpTeeth.png',
       knnData: [1, 0.125],
       type: FishBodyPart.MOUTH
@@ -173,26 +192,31 @@ const fish = {
   // SIDE FIN KNN DATA: [pointiness rank]
   pectoralFinsFront: {
     almond: {
+      index: 0,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Almond.png',
       knnData: [0.8],
       type: FishBodyPart.PECTORAL_FIN_FRONT
     },
     drop: {
+      index: 1,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Drop.png',
       knnData: [0.4],
       type: FishBodyPart.PECTORAL_FIN_FRONT
     },
     roundTriangle: {
+      index: 2,
       src: 'images/fish/pectoralFin/Pectoral_Fin_RoundTriangle.png',
       knnData: [0.6],
       type: FishBodyPart.PECTORAL_FIN_FRONT
     },
     sharp: {
+      index: 3,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Sharp.png',
       knnData: [1],
       type: FishBodyPart.PECTORAL_FIN_FRONT
     },
     standard: {
+      index: 4,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Standard.png',
       knnData: [0.2],
       type: FishBodyPart.PECTORAL_FIN_FRONT
@@ -200,26 +224,31 @@ const fish = {
   },
   pectoralFinsBack: {
     almond: {
+      index: 0,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Almond.png',
       knnData: [0.8],
       type: FishBodyPart.PECTORAL_FIN_BACK
     },
     drop: {
+      index: 1,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Drop.png',
       knnData: [0.4],
       type: FishBodyPart.PECTORAL_FIN_BACK
     },
     roundTriangle: {
+      index: 2,
       src: 'images/fish/pectoralFin/Pectoral_Fin_RoundTriangle.png',
       knnData: [0.6],
       type: FishBodyPart.PECTORAL_FIN_BACK
     },
     sharp: {
+      index: 3,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Sharp.png',
       knnData: [1],
       type: FishBodyPart.PECTORAL_FIN_BACK
     },
     standard: {
+      index: 4,
       src: 'images/fish/pectoralFin/Pectoral_Fin_Standard.png',
       knnData: [0.2],
       type: FishBodyPart.PECTORAL_FIN_BACK
@@ -229,6 +258,7 @@ const fish = {
   // TOP FIN KNN DATA: [pointiness rank]
   topFins: {
     almond: {
+      index: 0,
       src: 'images/fish/dorsalFin/Dorsal_Fin_Almond.png',
       knnData: [1],
       type: FishBodyPart.DORSAL_FIN
@@ -246,21 +276,25 @@ const fish = {
     },
     */
     mohawk: {
+      index: 1,
       src: 'images/fish/dorsalFin/Dorsal_Fin_Mohawk.png',
       knnData: [0.5],
       type: FishBodyPart.DORSAL_FIN
     },
     oval: {
+      index: 2,
       src: 'images/fish/dorsalFin/Dorsal_Fin_Oval.png',
       knnData: [0],
       type: FishBodyPart.DORSAL_FIN
     },
     shark: {
+      index: 3,
       src: 'images/fish/dorsalFin/Dorsal_Fin_Shark.png',
       knnData: [0.875],
       type: FishBodyPart.DORSAL_FIN
     },
     spikes: {
+      index: 4,
       src: 'images/fish/dorsalFin/Dorsal_Fin_Spikes.png',
       knnData: [0.75],
       type: FishBodyPart.DORSAL_FIN
@@ -271,6 +305,7 @@ const fish = {
       type: FishBodyPart.DORSAL_FIN
     },*/
     wave: {
+      index: 5,
       src: 'images/fish/dorsalFin/Dorsal_Fin_Wave.png',
       knnData: [0.375],
       type: FishBodyPart.DORSAL_FIN
@@ -279,31 +314,37 @@ const fish = {
   // TAIL KNN DATA: [sections, width]
   tails: {
     almond: {
+      index: 0,
       src: 'images/fish/tailFin/Tail_Fin_Almond.png',
       knnData: [1],
       type: FishBodyPart.TAIL
     },
     bean: {
+      index: 1,
       src: 'images/fish/tailFin/Tail_Fin_Bean.png',
       knnData: [0.64],
       type: FishBodyPart.TAIL
     },
     clamshell: {
+      index: 2,
       src: 'images/fish/tailFin/Tail_Fin_Clamshell.png',
       knnData: [0.56],
       type: FishBodyPart.TAIL
     },
     roundedHeart: {
+      index: 3,
       src: 'images/fish/tailFin/Tail_Fin_RoundedHeart.png',
       knnData: [0.97],
       type: FishBodyPart.TAIL
     },
     roundedTriangle: {
+      index: 4,
       src: 'images/fish/tailFin/Tail_Fin_RoundedTriangle.png',
       knnData: [0],
       type: FishBodyPart.TAIL
     },
     sharp: {
+      index: 5,
       src: 'images/fish/tailFin/Tail_Fin_Sharp.png',
       knnData: [0.57],
       type: FishBodyPart.TAIL
@@ -366,7 +407,7 @@ const fish = {
   }
 };
 
-export default fish;
+export default fishData;
 
 export const bodyShape = PropTypes.shape({
   src: PropTypes.string.isRequired,

--- a/src/utils/fishData.js
+++ b/src/utils/fishData.js
@@ -116,7 +116,7 @@ const fishData = {
     concentric: {
       index: 2,
       src: 'images/fish/eyes/Eyes_Concentric.png',
-      knnData: [1, 1.00],
+      knnData: [1, 1.0],
       type: FishBodyPart.EYE
     },
     side: {
@@ -179,7 +179,7 @@ const fishData = {
     shark: {
       index: 7,
       src: 'images/fish/mouth/Mouth_Shark.png',
-      knnData: [1, 0.00],
+      knnData: [1, 0.0],
       type: FishBodyPart.MOUTH
     },
     sharpTeeth: {
@@ -262,12 +262,12 @@ const fishData = {
       src: 'images/fish/dorsalFin/Dorsal_Fin_Almond.png',
       knnData: [1],
       type: FishBodyPart.DORSAL_FIN
-    },/*
+    } /*
     anglerfish: {
       src: 'images/fish/dorsalFin/Dorsal_Fin_anglerfish.png',
       knnData: [0.125],
       type: FishBodyPart.DORSAL_FIN
-    },*/
+    },*/,
     /*
     horns: {
       src: 'images/fish/dorsalFin/Dorsal_Fin_Horns.png',
@@ -298,12 +298,12 @@ const fishData = {
       src: 'images/fish/dorsalFin/Dorsal_Fin_Spikes.png',
       knnData: [0.75],
       type: FishBodyPart.DORSAL_FIN
-    },/*
+    } /*
     topHat: {
       src: 'images/fish/dorsalFin/Dorsal_Fin_TopHat.png',
       knnData: [0.25],
       type: FishBodyPart.DORSAL_FIN
-    },*/
+    },*/,
     wave: {
       index: 5,
       src: 'images/fish/dorsalFin/Dorsal_Fin_Wave.png',

--- a/src/utils/generateOcean.js
+++ b/src/utils/generateOcean.js
@@ -1,7 +1,8 @@
-import fish from './fishData';
-//const _ = require('lodash');
+import fishData from './fishData';
 
 export const generateRandomFish = id => {
+  const fish = fishData;
+
   const bodies = Object.values(fish.bodies);
   const eyes = Object.values(fish.eyes);
   const mouths = Object.values(fish.mouths);


### PR DESCRIPTION
Previously, the fish renderer would attempt to load fish part images over the network any time it had to draw a new fish.

Now, we preload all known fish part images upfront in a new "loading" mode, then cache these in canvases, and use those whenever we draw a new fish.

Note that tinting is still done at individual fish render time.