### PR TITLE
Training mode gets temporary text counters for yes/no choices

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -121,6 +121,20 @@
         width: 100%;
         text-align: center;
       }
+      #train-counter-yes-text {
+        position: absolute;
+        top: 0px;
+        right: 10%;
+        font-size: 24px;
+        color: green;
+      }
+      #train-counter-no-text {
+        position: absolute;
+        top: 0px;
+        right: 3%;
+        font-size: 24px;
+        color: red;
+      }
       .show-code-toggle {
         position: absolute;
         top: 5px;

--- a/src/demo/models/pond.js
+++ b/src/demo/models/pond.js
@@ -62,7 +62,9 @@ const arrangeFish = fishes => {
 
 const onClickStartOver = () => {
   const state = setState({
-    iterationCount: getState().iterationCount + 1
+    iterationCount: getState().iterationCount + 1,
+    yesCount: 0,
+    noCount: 0
   });
   state.trainer.clearAll();
   toMode(Modes.Words);

--- a/src/demo/models/train.js
+++ b/src/demo/models/train.js
@@ -1,3 +1,4 @@
+import $ from 'jquery';
 import 'babel-polyfill';
 import {setState, getState} from '../state';
 import {Modes, ClassType} from '../constants';
@@ -56,7 +57,9 @@ export const init = () => {
 const uiElements = state => {
   return [
     ...staticUiElements,
-    createText({id: 'train-text', text: `Is this fish ${state.word}?`})
+    createText({id: 'train-text', text: `Is this fish ${state.word}?`}),
+    createText({id: 'train-counter-yes-text', text: ""}),
+    createText({id: 'train-counter-no-text', text: ""})
   ];
 };
 
@@ -70,6 +73,16 @@ const onClassifyFish = doesLike => {
   if (state.trainingIndex > state.fishData.length - 5) {
     const fishData = state.fishData.concat(generateOcean(100));
     setState({fishData});
+  }
+  if (doesLike) {
+    const newValue = getState().yesCount + 1;
+    setState({yesCount: newValue});
+    $("#train-counter-yes-text").text(newValue);
+
+  } else {
+    const newValue = getState().noCount + 1;
+    setState({noCount: newValue});
+    $("#train-counter-no-text").text(newValue);
   }
 };
 

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -13,7 +13,9 @@ const initialState = {
   headerElements: [],
   footerContainer: null,
   footerElements: [],
-  iterationCount: 0
+  iterationCount: 0,
+  yesCount: 0,
+  noCount: 0
 };
 let state = {...initialState};
 


### PR DESCRIPTION
While we plan to eventually show this graphically, for the upcoming play test we're going to show two text counters in the top-right corner of training mode showing the counter of yes & no choices.  The counters are reset when the user starts over, since the current UI has them choose a new word each iteration.

![Screenshot 2019-10-23 15 11 12](https://user-images.githubusercontent.com/2205926/67438318-f7f6c900-f5a7-11e9-8db2-93ac24eaba79.png)
