### PR TITLE
Style predictions

### DIFF
--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -192,9 +192,7 @@ const drawMovingFish = state => {
 
     if (state.currentMode === Modes.Predicting) {
       if (fish.result) {
-        ctx.fillStyle =
-          fish.result.predictedClassId === ClassType.Like ? 'green' : 'red';
-        ctx.fillRect(x, y, 10, 10);
+        drawPrediction(fish.result.predictedClassId, state.word, x, y, ctx);
       } else {
         predictFish(state, i).then(prediction => {
           fish.result = prediction;
@@ -206,6 +204,19 @@ const drawMovingFish = state => {
   if (state.currentMode === Modes.Training && runtime === MOVE_TIME) {
     finishMovement();
   }
+};
+
+const drawPrediction = (predictedClassId, text, x, y, ctx) => {
+  const centeredX = x + constants.fishCanvasWidth / 2;
+  const doesLike = predictedClassId === ClassType.Like;
+
+  ctx.fillStyle = doesLike ? 'green' : 'red';
+  ctx.font = '20px Arial';
+  ctx.textAlign = 'center';
+  if (!doesLike) {
+    text = 'not ' + text;
+  }
+  ctx.fillText(text.toUpperCase(), centeredX, y);
 };
 
 // Draw frame in the center of the screen.

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -206,6 +206,7 @@ const drawMovingFish = state => {
   }
 };
 
+// Draw a prediction to the canvas.
 const drawPrediction = (predictedClassId, text, x, y, ctx) => {
   const centeredX = x + constants.fishCanvasWidth / 2;
   const doesLike = predictedClassId === ClassType.Like;


### PR DESCRIPTION
Update the prediction screen to display text prediction with color-coding instead of little dots:

<img width="970" alt="Screen Shot 2019-10-24 at 10 06 58 AM" src="https://user-images.githubusercontent.com/9812299/67511153-25488300-f64b-11e9-96fd-c73358384541.png">
