### PR TITLE
fix package.json repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/code-dot-org/dance-party.git"
+    "url": "git+ssh://git@github.com/code-dot-org/ml-activities.git"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
* `package.json` had an outdated reference to `dance-party.git` - now fixed!