### PR TITLE
Delay predict "Skip" button display

### DIFF
--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -79,6 +79,8 @@ export const render = () => {
 
   clearCanvas(state.canvas);
 
+  const timeBeforeCanSkipPredict = 5000;
+
   switch (state.currentMode) {
     case Modes.Training:
       updateTrainText(state);
@@ -86,9 +88,7 @@ export const render = () => {
       drawMovingFish(state);
       break;
     case Modes.Predicting:
-      const timeBeforeCanSkipPredict = 5000;
       setState({canSkipPredict: $time() >= currentModeStartTime + timeBeforeCanSkipPredict});
-
       drawMovingFish(state);
       break;
     case Modes.Pond:

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -86,6 +86,9 @@ export const render = () => {
       drawMovingFish(state);
       break;
     case Modes.Predicting:
+      const timeBeforeCanSkipPredict = 5000;
+      setState({canSkipPredict: $time() >= currentModeStartTime + timeBeforeCanSkipPredict});
+
       drawMovingFish(state);
       break;
     case Modes.Pond:

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -18,7 +18,8 @@ const initialState = {
   iterationCount: 0,
   isRunning: false,
   yesCount: 0,
-  noCount: 0
+  noCount: 0,
+  canSkipPredict: false
 };
 let state = {...initialState};
 

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -362,17 +362,21 @@ class Train extends React.Component {
 
 class Predict extends React.Component {
   render() {
+    const state = getState();
+
     return (
       <Body>
         <Header>A.I. Sorting</Header>
         <img style={styles.predictBot} src="images/ai-bot-closed.png" />
         <Footer>
-          <Button
-            style={styles.continueButton}
-            onClick={() => toMode(Modes.Pond)}
-          >
-            Skip
-          </Button>
+          {state.canSkipPredict && (
+            <Button
+              style={styles.continueButton}
+              onClick={() => toMode(Modes.Pond)}
+            >
+              Skip
+            </Button>
+          )}
         </Footer>
       </Body>
     );


### PR DESCRIPTION
I noticed that I would hit the "Skip" button in the prediction screen very quickly.  This proposal puts a 5 second delay before it appears.