### PR TITLE
Draw fish on integer coordinates

### DIFF
--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -295,7 +295,8 @@ const drawSingleFish = (fish, fishXPos, fishYPos, ctx) => {
     fishCanvas.height = constants.fishCanvasHeight;
     fish.drawToCanvas(fishCanvas);
   }
-  ctx.drawImage(fishCanvas, fishXPos, fishYPos);
+
+  ctx.drawImage(fishCanvas, Math.round(fishXPos), Math.round(fishYPos));
 };
 
 // Clear the sprite canvas.


### PR DESCRIPTION
The swaying was introducing some non-integer coordinates for fish, and long ago I've seen canvas rendering get dramatically slower when this happens (presumably because it fell through to a slow-path software-based subpixel renderer).  As a catch-all, drawing fish now rounds the destination coordinates to integer X & Y first.