### PR TITLE
Exclude some fish bodies in "small" set

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "mem": ">=4.0.0",
     "node-fetch": "^2.6.0",
     "prettier": "1.16.1",
+    "query-string": "4.1.0",
     "react": "~15.4.0",
     "react-bootstrap": "0.30.1",
     "react-color": "^2.17.3",

--- a/src/demo/OceanObject.js
+++ b/src/demo/OceanObject.js
@@ -58,9 +58,9 @@ export const loadAllFishPartImages = () => {
   );
 };
 
-export const generateOceanObject = (allowedClasses, id) => {
+export const generateOceanObject = (allowedClasses, id, dataSet = null) => {
   const idx = Math.floor(Math.random() * allowedClasses.length);
-  const newOceanObject = new allowedClasses[idx](id);
+  const newOceanObject = new allowedClasses[idx](id, dataSet);
   newOceanObject.randomize();
   return newOceanObject;
 };
@@ -97,18 +97,22 @@ export class OceanObject {
   }
 }
 
+const filterExclusions = (component, dataSet) => {
+  return Object.values(component).filter(
+    option => !(option.exclusions || []).includes(dataSet)
+  );
+};
+
 export class FishOceanObject extends OceanObject {
-  constructor(id) {
+  constructor(id, dataSet = null) {
     super(id);
-    const fish = fishData;
-    this.bodies = Object.values(fish.bodies);
-    this.eyes = Object.values(fish.eyes);
-    this.mouths = Object.values(fish.mouths);
-    this.pectoralFinsFront = Object.values(fish.pectoralFinsFront);
-    this.pectoralFinsBack = Object.values(fish.pectoralFinsBack);
-    this.dorsalFins = Object.values(fish.dorsalFins);
-    this.tails = Object.values(fish.tails);
-    this.colorPalettes = Object.values(fish.colorPalettes);
+    let scopedThis = this;
+    Object.keys(fishData).forEach(componentKey => {
+      scopedThis[componentKey] = filterExclusions(
+        fishData[componentKey],
+        dataSet
+      );
+    });
   }
 
   randomize() {

--- a/src/demo/OceanObject.js
+++ b/src/demo/OceanObject.js
@@ -4,7 +4,8 @@ import {
   bodyAnchorFromType,
   colorForFishPart,
   randomInt,
-  clamp
+  clamp,
+  filterFishComponents
 } from './helpers';
 import _ from 'lodash';
 
@@ -62,25 +63,10 @@ export const generateOceanObject = (allowedClasses, id, dataSet = null) => {
   const idx = Math.floor(Math.random() * allowedClasses.length);
   const newOceanObject = new allowedClasses[idx](
     id,
-    filterFishComponents(dataSet)
+    filterFishComponents(fishData, dataSet)
   );
   newOceanObject.randomize();
   return newOceanObject;
-};
-
-const filterFishComponents = dataSet => {
-  if (!dataSet) {
-    return fishData;
-  }
-
-  let filteredCopy = {...fishData};
-  Object.keys(filteredCopy).forEach(key => {
-    filteredCopy[key] = Object.values(filteredCopy[key]).filter(
-      option => !(option.exclusions || []).includes(dataSet)
-    );
-  });
-
-  return filteredCopy;
 };
 
 export class OceanObject {

--- a/src/demo/OceanObject.js
+++ b/src/demo/OceanObject.js
@@ -60,9 +60,27 @@ export const loadAllFishPartImages = () => {
 
 export const generateOceanObject = (allowedClasses, id, dataSet = null) => {
   const idx = Math.floor(Math.random() * allowedClasses.length);
-  const newOceanObject = new allowedClasses[idx](id, dataSet);
+  const newOceanObject = new allowedClasses[idx](
+    id,
+    filterFishComponents(dataSet)
+  );
   newOceanObject.randomize();
   return newOceanObject;
+};
+
+const filterFishComponents = dataSet => {
+  if (!dataSet) {
+    return fishData;
+  }
+
+  let filteredCopy = {...fishData};
+  Object.keys(filteredCopy).forEach(key => {
+    filteredCopy[key] = Object.values(filteredCopy[key]).filter(
+      option => !(option.exclusions || []).includes(dataSet)
+    );
+  });
+
+  return filteredCopy;
 };
 
 export class OceanObject {
@@ -97,22 +115,17 @@ export class OceanObject {
   }
 }
 
-const filterExclusions = (component, dataSet) => {
-  return Object.values(component).filter(
-    option => !(option.exclusions || []).includes(dataSet)
-  );
-};
-
 export class FishOceanObject extends OceanObject {
-  constructor(id, dataSet = null) {
+  constructor(id, componentOptions) {
     super(id);
-    let scopedThis = this;
-    Object.keys(fishData).forEach(componentKey => {
-      scopedThis[componentKey] = filterExclusions(
-        fishData[componentKey],
-        dataSet
-      );
-    });
+    this.bodies = Object.values(componentOptions.bodies);
+    this.eyes = Object.values(componentOptions.eyes);
+    this.mouths = Object.values(componentOptions.mouths);
+    this.pectoralFinsFront = Object.values(componentOptions.pectoralFinsFront);
+    this.pectoralFinsBack = Object.values(componentOptions.pectoralFinsBack);
+    this.dorsalFins = Object.values(componentOptions.dorsalFins);
+    this.tails = Object.values(componentOptions.tails);
+    this.colorPalettes = Object.values(componentOptions.colorPalettes);
   }
 
   randomize() {

--- a/src/demo/constants.js
+++ b/src/demo/constants.js
@@ -24,8 +24,7 @@ export const ClassType = Object.freeze({
 
 // Describes the current data set and whether it is restricted
 // (e.g., if DataSet.Small === true, we may restrict which words
-// or fish the student sees)
+// or fish the student sees).
 export const DataSet = Object.freeze({
-  None: 0,
-  Small: 1
+  Small: 'small'
 });

--- a/src/demo/constants.js
+++ b/src/demo/constants.js
@@ -23,7 +23,7 @@ export const ClassType = Object.freeze({
 });
 
 // Describes the current data set and whether it is restricted
-// (e.g., if DataSet.Small === true, we may restrict which words
+// (e.g., if DataSet.Small === true, we will restrict which words
 // or fish the student sees).
 export const DataSet = Object.freeze({
   Small: 'small'

--- a/src/demo/constants.js
+++ b/src/demo/constants.js
@@ -21,3 +21,11 @@ export const ClassType = Object.freeze({
   Like: 0,
   Dislike: 1
 });
+
+// Describes the current data set and whether it is restricted
+// (e.g., if DataSet.Small === true, we may restrict which words
+// or fish the student sees)
+export const DataSet = Object.freeze({
+  None: 0,
+  Small: 1
+});

--- a/src/demo/helpers.js
+++ b/src/demo/helpers.js
@@ -72,3 +72,18 @@ export const clamp = (value, min, max) => {
 export const queryStrFor = key => {
   return queryString.parse(location.search)[key];
 };
+
+export const filterFishComponents = (fishComponents, dataSet) => {
+  if (!dataSet) {
+    return fishComponents;
+  }
+
+  let filteredCopy = {...fishComponents};
+  Object.keys(filteredCopy).forEach(key => {
+    filteredCopy[key] = Object.values(filteredCopy[key]).filter(
+      option => !(option.exclusions || []).includes(dataSet)
+    );
+  });
+
+  return filteredCopy;
+};

--- a/src/demo/helpers.js
+++ b/src/demo/helpers.js
@@ -73,6 +73,22 @@ export const queryStrFor = key => {
   return queryString.parse(location.search)[key];
 };
 
+/**
+ * Given fishComponents and a dataSet, will filter any components that should be excluded in that dataSet.
+ * Example input: {
+ *   bodies: {
+ *     body1: {src: 'images/body1.png'},
+ *     body2: {
+ *       src: 'images/body2.png',
+ *       exclusions: [DataSet.Small]
+ *     }
+ *   }
+ * }, DataSet.Small
+ *
+ * Example output: {
+ *   bodies: [{src: 'images/body1.png'}]
+ * }
+ */
 export const filterFishComponents = (fishComponents, dataSet) => {
   if (!dataSet) {
     return fishComponents;

--- a/src/demo/helpers.js
+++ b/src/demo/helpers.js
@@ -1,3 +1,4 @@
+import queryString from 'query-string';
 import {Modes} from './constants';
 import {FishBodyPart} from '../utils/fishData';
 
@@ -65,4 +66,9 @@ export const randomInt = (min, max) => {
 
 export const clamp = (value, min, max) => {
   return Math.min(Math.max(value, min), max);
+};
+
+// Given a key, returns the value from the browser's current query params.
+export const queryStrFor = key => {
+  return queryString.parse(location.search)[key];
 };

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -3,6 +3,7 @@ import constants, {Modes} from './constants';
 import {setState, setSetStateCallback} from './state';
 import {init as initModel} from './models';
 import {render as renderCanvas} from './renderer';
+import {queryStrFor} from './helpers';
 
 import 'babel-polyfill';
 import ReactDOM from 'react-dom';
@@ -17,14 +18,14 @@ $(document).ready(() => {
   canvas.height = backgroundCanvas.height = constants.canvasHeight;
 
   // Temporarily use URL parameter to set some state.
-  const smallWordSet = window.location.href.indexOf('words=small') !== -1;
+  const dataSet = queryStrFor('set') && queryStrFor('set').toLowerCase();
 
   // Set initial state for UI elements.
   const state = setState({
     currentMode: Modes.Loading,
     canvas,
     backgroundCanvas,
-    smallWordSet
+    dataSet
   });
 
   // Initialize our first model.

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -2,6 +2,7 @@ let setStateCallback = null;
 
 const initialState = {
   currentMode: null,
+  dataSet: null,
   fishData: [],
   pondFish: [],
   backgroundCanvas: null,

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -9,12 +9,6 @@ const initialState = {
   ctx: null,
   trainer: null,
   trainingIndex: 0,
-  uiContainer: null,
-  uiElements: [],
-  headerContainer: null,
-  headerElements: [],
-  footerContainer: null,
-  footerElements: [],
   iterationCount: 0,
   isRunning: false,
   yesCount: 0,
@@ -37,6 +31,6 @@ export const setState = function(newState) {
   return state;
 };
 
-export const setSetStateCallback = (callback) => {
+export const setSetStateCallback = callback => {
   setStateCallback = callback;
-}
+};

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {getState, setState} from './state';
-import {Modes} from './constants';
+import {Modes, DataSet} from './constants';
 import {toMode} from './toMode';
 import {init as initModel} from './models';
 import {onClassifyFish} from './models/train';
@@ -266,7 +266,7 @@ class Words extends React.Component {
 
   currentItems() {
     const state = getState();
-    const itemSet = state.smallWordSet ? 0 : 1;
+    const itemSet = state.dataSet === DataSet.Small ? 0 : 1;
 
     return this.state.choices[itemSet];
   }
@@ -282,9 +282,8 @@ class Words extends React.Component {
   render() {
     const state = getState();
     const currentItems = this.currentItems();
-    const buttonStyle = state.smallWordSet
-      ? styles.button1col
-      : styles.button3col;
+    const buttonStyle =
+      state.dataSet === DataSet.Small ? styles.button1col : styles.button3col;
 
     return (
       <Body>

--- a/src/utils/fishData.js
+++ b/src/utils/fishData.js
@@ -27,8 +27,6 @@ const BodyShape = Object.freeze({
   OTHER: 4
 });
 
-let initialized = false;
-
 const fishComponents = {
   // BODY KNN DATA: [area, BodyShape]
   bodies: {
@@ -700,6 +698,7 @@ const fishComponents = {
 };
 
 // Normalize the KNN data for all components.
+let initialized = false;
 export const initFishData = () => {
   if (!initialized) {
     Object.keys(fishComponents).forEach(key => {

--- a/src/utils/fishData.js
+++ b/src/utils/fishData.js
@@ -1,3 +1,5 @@
+import {DataSet} from '../demo/constants';
+
 // Describe the different body parts of the fish. The object
 // is ordered by its render dependency (i.e., dorsalFin should be rendered
 // before body).
@@ -38,7 +40,8 @@ const fishComponents = {
       dorsalFinAnchor: [23, -15],
       tailAnchor: [107, 41],
       knnData: [7120, BodyShape.OVAL],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: [DataSet.Small]
     },
     fish3: {
       src: 'images/fish/body/Body_Fish3.png',
@@ -51,7 +54,7 @@ const fishComponents = {
       tailAnchor: [120, 38],
       knnData: [6384, BodyShape.OVAL],
       type: FishBodyPart.BODY,
-      exclusions: ['small']
+      exclusions: [DataSet.Small]
     },
     fish1: {
       src: 'images/fish/body/Body_Fish1.png',
@@ -63,8 +66,7 @@ const fishComponents = {
       dorsalFinAnchor: [20, -18],
       tailAnchor: [97, 50],
       knnData: [8004, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     fish2: {
       src: 'images/fish/body/Body_Fish2.png',
@@ -76,8 +78,7 @@ const fishComponents = {
       dorsalFinAnchor: [33, -19],
       tailAnchor: [92, 47],
       knnData: [7895, BodyShape.SQUARE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     fish4: {
       src: 'images/fish/body/Body_Fish4.png',
@@ -90,7 +91,7 @@ const fishComponents = {
       tailAnchor: [139, 19],
       knnData: [9078, BodyShape.TRIANGLE],
       type: FishBodyPart.BODY,
-      exclusions: ['small']
+      exclusions: [DataSet.Small]
     },
     wide1: {
       src: 'images/fish/body/Body_Wide1.png',
@@ -102,8 +103,7 @@ const fishComponents = {
       dorsalFinAnchor: [40, -23],
       tailAnchor: [157, 81],
       knnData: [20864, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     fish5: {
       src: 'images/fish/body/Body_Fish5.png',
@@ -115,8 +115,7 @@ const fishComponents = {
       dorsalFinAnchor: [30, -18],
       tailAnchor: [125, 68],
       knnData: [12844, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     wide2: {
       src: 'images/fish/body/Body_Wide2.png',
@@ -128,8 +127,7 @@ const fishComponents = {
       dorsalFinAnchor: [60, -23],
       tailAnchor: [154, 81],
       knnData: [17970, BodyShape.OVAL],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     square1: {
       src: 'images/fish/body/Body_Square1.png',
@@ -141,8 +139,7 @@ const fishComponents = {
       dorsalFinAnchor: [25, -23],
       tailAnchor: [97, 45],
       knnData: [8463, BodyShape.SQUARE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     square2: {
       src: 'images/fish/body/Body_Square2.png',
@@ -154,8 +151,7 @@ const fishComponents = {
       dorsalFinAnchor: [27, -23],
       tailAnchor: [93, 59],
       knnData: [12327, BodyShape.SQUARE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     spikey1: {
       src: 'images/fish/body/Body_Spikey1.png',
@@ -167,8 +163,7 @@ const fishComponents = {
       dorsalFinAnchor: [53, -23],
       tailAnchor: [125, 74],
       knnData: [13584, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     spikey2: {
       src: 'images/fish/body/Body_Spikey2.png',
@@ -180,8 +175,7 @@ const fishComponents = {
       dorsalFinAnchor: [43, -20],
       tailAnchor: [125, 64],
       knnData: [14558, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     sharp1: {
       src: 'images/fish/body/Body_Sharp1.png',
@@ -194,7 +188,7 @@ const fishComponents = {
       tailAnchor: [144, 56],
       knnData: [12419, BodyShape.TRIANGLE],
       type: FishBodyPart.BODY,
-      exclusions: ['small']
+      exclusions: [DataSet.Small]
     },
     sharp2: {
       src: 'images/fish/body/Body_Sharp2.png',
@@ -207,7 +201,7 @@ const fishComponents = {
       tailAnchor: [144, 56],
       knnData: [9732, BodyShape.TRIANGLE],
       type: FishBodyPart.BODY,
-      exclusions: ['small']
+      exclusions: [DataSet.Small]
     },
     round1: {
       src: 'images/fish/body/Body_Round1.png',
@@ -219,8 +213,7 @@ const fishComponents = {
       dorsalFinAnchor: [41, -13],
       tailAnchor: [118, 62],
       knnData: [12466, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     round2: {
       src: 'images/fish/body/Body_Round2.png',
@@ -232,8 +225,7 @@ const fishComponents = {
       dorsalFinAnchor: [25, -20],
       tailAnchor: [74, 39],
       knnData: [4876, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     narrow1: {
       src: 'images/fish/body/Body_Narrow1.png',
@@ -245,8 +237,7 @@ const fishComponents = {
       dorsalFinAnchor: [22, -13],
       tailAnchor: [62, 62],
       knnData: [6714, BodyShape.OVAL],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     },
     narrow2: {
       src: 'images/fish/body/Body_Narrow2.png',
@@ -258,8 +249,7 @@ const fishComponents = {
       dorsalFinAnchor: [76, -20],
       tailAnchor: [154, 19],
       knnData: [7120, BodyShape.OVAL],
-      type: FishBodyPart.BODY,
-      exclusions: ['small']
+      type: FishBodyPart.BODY
     }
   },
   // EYE KNN DATA: [eye area, eye:pupil ratio]

--- a/src/utils/fishData.js
+++ b/src/utils/fishData.js
@@ -50,7 +50,8 @@ const fishComponents = {
       dorsalFinAnchor: [53, -25],
       tailAnchor: [120, 38],
       knnData: [6384, BodyShape.OVAL],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     fish1: {
       src: 'images/fish/body/Body_Fish1.png',
@@ -62,7 +63,8 @@ const fishComponents = {
       dorsalFinAnchor: [20, -18],
       tailAnchor: [97, 50],
       knnData: [8004, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     fish2: {
       src: 'images/fish/body/Body_Fish2.png',
@@ -74,7 +76,8 @@ const fishComponents = {
       dorsalFinAnchor: [33, -19],
       tailAnchor: [92, 47],
       knnData: [7895, BodyShape.SQUARE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     fish4: {
       src: 'images/fish/body/Body_Fish4.png',
@@ -86,7 +89,8 @@ const fishComponents = {
       dorsalFinAnchor: [33, -23],
       tailAnchor: [139, 19],
       knnData: [9078, BodyShape.TRIANGLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     wide1: {
       src: 'images/fish/body/Body_Wide1.png',
@@ -98,7 +102,8 @@ const fishComponents = {
       dorsalFinAnchor: [40, -23],
       tailAnchor: [157, 81],
       knnData: [20864, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     fish5: {
       src: 'images/fish/body/Body_Fish5.png',
@@ -110,7 +115,8 @@ const fishComponents = {
       dorsalFinAnchor: [30, -18],
       tailAnchor: [125, 68],
       knnData: [12844, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     wide2: {
       src: 'images/fish/body/Body_Wide2.png',
@@ -122,7 +128,8 @@ const fishComponents = {
       dorsalFinAnchor: [60, -23],
       tailAnchor: [154, 81],
       knnData: [17970, BodyShape.OVAL],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     square1: {
       src: 'images/fish/body/Body_Square1.png',
@@ -134,7 +141,8 @@ const fishComponents = {
       dorsalFinAnchor: [25, -23],
       tailAnchor: [97, 45],
       knnData: [8463, BodyShape.SQUARE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     square2: {
       src: 'images/fish/body/Body_Square2.png',
@@ -146,7 +154,8 @@ const fishComponents = {
       dorsalFinAnchor: [27, -23],
       tailAnchor: [93, 59],
       knnData: [12327, BodyShape.SQUARE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     spikey1: {
       src: 'images/fish/body/Body_Spikey1.png',
@@ -158,7 +167,8 @@ const fishComponents = {
       dorsalFinAnchor: [53, -23],
       tailAnchor: [125, 74],
       knnData: [13584, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     spikey2: {
       src: 'images/fish/body/Body_Spikey2.png',
@@ -170,7 +180,8 @@ const fishComponents = {
       dorsalFinAnchor: [43, -20],
       tailAnchor: [125, 64],
       knnData: [14558, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     sharp1: {
       src: 'images/fish/body/Body_Sharp1.png',
@@ -182,7 +193,8 @@ const fishComponents = {
       dorsalFinAnchor: [76, -13],
       tailAnchor: [144, 56],
       knnData: [12419, BodyShape.TRIANGLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     sharp2: {
       src: 'images/fish/body/Body_Sharp2.png',
@@ -194,7 +206,8 @@ const fishComponents = {
       dorsalFinAnchor: [43, -20],
       tailAnchor: [144, 56],
       knnData: [9732, BodyShape.TRIANGLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     round1: {
       src: 'images/fish/body/Body_Round1.png',
@@ -206,7 +219,8 @@ const fishComponents = {
       dorsalFinAnchor: [41, -13],
       tailAnchor: [118, 62],
       knnData: [12466, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     round2: {
       src: 'images/fish/body/Body_Round2.png',
@@ -218,7 +232,8 @@ const fishComponents = {
       dorsalFinAnchor: [25, -20],
       tailAnchor: [74, 39],
       knnData: [4876, BodyShape.CIRCLE],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     narrow1: {
       src: 'images/fish/body/Body_Narrow1.png',
@@ -230,7 +245,8 @@ const fishComponents = {
       dorsalFinAnchor: [22, -13],
       tailAnchor: [62, 62],
       knnData: [6714, BodyShape.OVAL],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     },
     narrow2: {
       src: 'images/fish/body/Body_Narrow2.png',
@@ -242,7 +258,8 @@ const fishComponents = {
       dorsalFinAnchor: [76, -20],
       tailAnchor: [154, 19],
       knnData: [7120, BodyShape.OVAL],
-      type: FishBodyPart.BODY
+      type: FishBodyPart.BODY,
+      exclusions: ['small']
     }
   },
   // EYE KNN DATA: [eye area, eye:pupil ratio]

--- a/src/utils/generateOcean.js
+++ b/src/utils/generateOcean.js
@@ -1,9 +1,11 @@
 import {FishOceanObject, generateOceanObject} from '../demo/OceanObject';
+import {getState} from '../demo/state';
 
 export const generateOcean = numFish => {
+  const state = getState();
   const ocean = [];
   for (var i = 0; i < numFish; ++i) {
-    ocean.push(generateOceanObject([FishOceanObject], i));
+    ocean.push(generateOceanObject([FishOceanObject], i, state.dataSet));
   }
   return ocean;
 };

--- a/test/unit/demo/helpers.test.js
+++ b/test/unit/demo/helpers.test.js
@@ -1,0 +1,42 @@
+import {filterFishComponents} from '../../../src/demo/helpers';
+import {DataSet} from '../../../src/demo/constants';
+
+describe('filterFishComponents', () => {
+  const fishComponents = {
+    bodies: {
+      body1: {src: 'images/body1.png', exclusions: []},
+      body2: {src: 'images/body2.png'},
+      body3: {
+        src: 'images/body3.png',
+        exclusions: [DataSet.Small, 'other-exclusion']
+      }
+    },
+    eyes: {
+      eye1: {src: 'images/eye1.png'},
+      eye2: {src: 'images/eye2.png', exclusions: [DataSet.Small]}
+    }
+  };
+
+  it('returns all components if no dataSet is defined', () => {
+    expect(filterFishComponents(fishComponents, null)).toEqual(fishComponents);
+    expect(filterFishComponents(fishComponents, undefined)).toEqual(
+      fishComponents
+    );
+  });
+
+  it('filters components that should be excluded in the given dataSet', () => {
+    const filteredComponents = filterFishComponents(
+      fishComponents,
+      DataSet.Small
+    );
+
+    expect(Object.keys(filteredComponents)).toEqual(
+      Object.keys(fishComponents)
+    );
+    expect(filteredComponents.bodies).toEqual([
+      fishComponents.bodies.body1,
+      fishComponents.bodies.body2
+    ]);
+    expect(filteredComponents.eyes).toEqual([fishComponents.eyes.eye1]);
+  });
+});

--- a/test/unit/utils/SimpleTrainer.test.js
+++ b/test/unit/utils/SimpleTrainer.test.js
@@ -1,4 +1,4 @@
-const SimpleTrainer = require('../../src/utils/SimpleTrainer');
+import SimpleTrainer from '../../../src/utils/SimpleTrainer';
 
 describe('Simple Trainer tests', () => {
   test('SimpleTrainer predicts', async () => {

--- a/test/unit/utils/generateOcean.test.js
+++ b/test/unit/utils/generateOcean.test.js
@@ -1,6 +1,6 @@
-const {initFishData} = require('../../src/utils/fishData');
-const {generateOcean, filterOcean} = require('../../src/utils/generateOcean');
-const SimpleTrainer = require('../../src/utils/SimpleTrainer');
+import {initFishData} from '../../../src/utils/fishData';
+import {generateOcean, filterOcean} from '../../../src/utils/generateOcean';
+import SimpleTrainer from '../../../src/utils/SimpleTrainer';
 
 describe('Generate ocean test', () => {
   beforeAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5807,6 +5807,13 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.1.0.tgz#a092273bcef2dddad4a2f0d4e1796701beb35a23"
+  integrity sha1-oJInO87y3drUovDU4XlnAb6zWiM=
+  dependencies:
+    strict-uri-encode "^1.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6695,6 +6702,11 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Refactors the `?words=small` URL param to `?set=small` so that we can restrict both the 1) set of words the user sees, and 2) the types of fish the user sees.

Each fish component can now define any `exclusions` so that we can filter those components out if necessary.

**Note:** Right now, we are filtering the fish components every time we call `generateOceanObject()`. I'm going to do a follow-up refactor so that this isn't necessary.