### PR TITLE
Clear evaluation canvas before using it

### DIFF
--- a/src/demo/OceanObject.js
+++ b/src/demo/OceanObject.js
@@ -118,6 +118,13 @@ export class OceanObject {
   getTensor() {
     if (mobilenet) {
       if (!this.logits) {
+        const evaluationCtx = evaluationCanvas.getContext('2d');
+        evaluationCtx.clearRect(
+          0,
+          0,
+          evaluationCanvas.width,
+          evaluationCanvas.height
+        );
         this.drawToCanvas(evaluationCanvas, false);
         this.generateLogits(evaluationCanvas);
       }


### PR DESCRIPTION
Fixes the issue where we only show a handful of fish when selecting fish vs trash. We were actually only showing the fish that were classified in the prediction screen because after that we draw to a temporary canvas that we were clearing.