### PR TITLE
Fix logic for adding indices to KNN data

### DIFF
--- a/src/utils/fishData.js
+++ b/src/utils/fishData.js
@@ -896,8 +896,9 @@ export const initFishData = () => {
         }
         component.index = idx;
         // Add an "id" to each component to train on
-        if (variations.length > 1) {
-          component.knnData.push(idx / (variations.length - 1));
+        const numVariations = Object.keys(variations).length;
+        if (numVariations > 1) {
+          component.knnData.push(idx / (numVariations - 1));
         }
       });
     });


### PR DESCRIPTION
Previously `variations.length` was undefined, leading to indices not actually being added for any fish components.