### PR TITLE
Set mode in the state using the URL only once

### DIFF
--- a/src/demo/helpers.js
+++ b/src/demo/helpers.js
@@ -107,19 +107,21 @@ export const filterFishComponents = (fishComponents, dataSet) => {
   return filteredCopy;
 };
 
-export const getAppMode = () => {
-  let appMode = null;
+// Get the base appMode (e.g. "instructions") & optional variant (e.g. "fishy")
+// from the appMode string (e.g. "fishy-instructions") stored in the provided state.
+export const getAppMode = state => {
+  let appModeBase = null;
   let appModeVariant = null;
 
-  if (queryStrFor('mode')) {
-    appMode = _.last(queryStrFor('mode').toLowerCase().split('-'));
+  if (state.appMode) {
+    appModeBase = _.last(state.appMode.toLowerCase().split('-'));
 
     // If the mode is "fishy-instrutions" then we extract "fishy" as the
     // appModeVariant.
-    if (appMode === "instructions") {
-      appModeVariant = queryStrFor('mode').toLowerCase().split('-')[0];
+    if (appModeBase === 'instructions') {
+      appModeVariant = state.appMode.toLowerCase().split('-')[0];
     }
   }
 
-  return [appMode, appModeVariant];
-}
+  return [appModeBase, appModeVariant];
+};

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -3,7 +3,7 @@ import constants, {Modes} from './constants';
 import {setState, setSetStateCallback} from './state';
 import {init as initModel} from './models';
 import {render as renderCanvas} from './renderer';
-import {queryStrFor} from './helpers';
+import {queryStrFor, getAppMode} from './helpers';
 
 import 'babel-polyfill';
 import ReactDOM from 'react-dom';
@@ -20,10 +20,12 @@ $(document).ready(() => {
   // Temporarily use URL parameter to set some state.
   const dataSet = queryStrFor('set') && queryStrFor('set').toLowerCase();
   const loadTrashImages = queryStrFor('mode') && queryStrFor('mode').toLowerCase() === 'fishvtrash';
+  const [appMode, appModeVariant] = getAppMode();
 
   // Set initial state for UI elements.
   const state = setState({
-    appMode: queryStrFor('mode'),
+    appMode: appMode,
+    appModeVariant: appModeVariant,
     currentMode: Modes.Loading,
     canvas,
     backgroundCanvas,

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -3,7 +3,7 @@ import constants, {Modes} from './constants';
 import {setState, setSetStateCallback} from './state';
 import {init as initModel} from './models';
 import {render as renderCanvas} from './renderer';
-import {queryStrFor, getAppMode} from './helpers';
+import {queryStrFor} from './helpers';
 
 import 'babel-polyfill';
 import ReactDOM from 'react-dom';
@@ -20,12 +20,11 @@ $(document).ready(() => {
   // Temporarily use URL parameter to set some state.
   const dataSet = queryStrFor('set') && queryStrFor('set').toLowerCase();
   const loadTrashImages = queryStrFor('mode') && queryStrFor('mode').toLowerCase() === 'fishvtrash';
-  const [appMode, appModeVariant] = getAppMode();
+  const appMode = queryStrFor('mode');
 
   // Set initial state for UI elements.
   const state = setState({
     appMode: appMode,
-    appModeVariant: appModeVariant,
     currentMode: Modes.Loading,
     canvas,
     backgroundCanvas,

--- a/src/demo/models/loading.js
+++ b/src/demo/models/loading.js
@@ -1,6 +1,6 @@
 import 'idempotent-babel-polyfill';
 import {initRenderer} from '../renderer';
-import {setState} from '../state';
+import {getState, setState} from '../state';
 import {Modes} from '../constants';
 import {init as initModel} from './index';
 import {initFishData} from '../../utils/fishData';
@@ -10,9 +10,8 @@ export const init = async () => {
   initFishData();
   await initRenderer();
 
-  const [appMode,] = getAppMode();
   const currentMode =
-    appMode === 'instructions' ? Modes.Instructions : Modes.ActivityIntro;
+    getState().appMode === 'instructions' ? Modes.Instructions : Modes.ActivityIntro;
 
   const state = setState({currentMode: currentMode});
   initModel(state);

--- a/src/demo/models/loading.js
+++ b/src/demo/models/loading.js
@@ -10,8 +10,9 @@ export const init = async () => {
   initFishData();
   await initRenderer();
 
+  const [appModeBase,] = getAppMode(getState());
   const currentMode =
-    getState().appMode === 'instructions' ? Modes.Instructions : Modes.ActivityIntro;
+    appModeBase === 'instructions' ? Modes.Instructions : Modes.ActivityIntro;
 
   const state = setState({currentMode: currentMode});
   initModel(state);

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -2,7 +2,6 @@ let setStateCallback = null;
 
 const initialState = {
   appMode: null,
-  appModeVariant: null,
   currentMode: null,
   dataSet: null,
   fishData: [],

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {getState, setState} from './state';
 import {Modes, DataSet} from './constants';
-import {getAppMode} from './helpers';
 import {toMode} from './toMode';
 import {init as initModel} from './models';
 import {onClassifyFish} from './models/train';
@@ -348,7 +347,7 @@ class Instructions extends React.Component {
   render() {
     const state = getState();
     const currentPage = state.currentInstructionsPage;
-    const [, appModeVariant] = getAppMode();
+    const appModeVariant = state.appModeVariant;
 
     return (
       <Body>

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import {getState, setState} from './state';
 import {Modes, DataSet} from './constants';
+import {getAppMode} from './helpers';
 import {toMode} from './toMode';
 import {init as initModel} from './models';
 import {onClassifyFish} from './models/train';
@@ -347,7 +348,7 @@ class Instructions extends React.Component {
   render() {
     const state = getState();
     const currentPage = state.currentInstructionsPage;
-    const appModeVariant = state.appModeVariant;
+    const [,appModeVariant] = getAppMode(state);
 
     return (
       <Body>


### PR DESCRIPTION
We were continually looking at the URL to determine what app mode we were in, which wouldn't have worked when integrated into studio.code.org.  Instead, we now rely upon the appMode initially stored in the state (e.g. "fishy-instructions") and extract the base appMode (e.g. "instructions") and optional appModeVariation (e.g. "fishy") from the state whenever we're curious about them.