### PR TITLE
Use the mode property properly again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@code-dot-org/ml-activities",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "main": "dist/main.js",
   "jest": {

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -16,19 +16,14 @@ $(document).ready(() => {
   canvas.width = backgroundCanvas.width = constants.canvasWidth;
   canvas.height = backgroundCanvas.height = constants.canvasHeight;
 
-  // Temporarily use URL parameter to set some state.
-  const dataSet = queryStrFor('set') && queryStrFor('set').toLowerCase();
-  const loadTrashImages =
-    queryStrFor('mode') && queryStrFor('mode').toLowerCase() === 'fishvtrash';
+  // Use URL parameter to set mode.
   const appMode = queryStrFor('mode');
 
   // Set initial state for UI elements.
   setState({
     appMode,
     canvas,
-    backgroundCanvas,
-    loadTrashImages,
-    dataSet
+    backgroundCanvas
   });
 
   // Initialize our first model.

--- a/src/demo/models/loading.js
+++ b/src/demo/models/loading.js
@@ -1,16 +1,21 @@
 import 'idempotent-babel-polyfill';
 import {initRenderer} from '../renderer';
-import {getState} from '../state';
-import {Modes} from '../constants';
+import {getState, setState} from '../state';
+import {Modes, DataSet} from '../constants';
 import {initFishData} from '../../utils/fishData';
 import {getAppMode} from '../helpers';
 import {toMode} from '../toMode';
 
 export const init = async () => {
+  const [appModeBase] = getAppMode(getState());
+
+  const dataSet = appModeBase === "short" ? DataSet.Small : DataSet.Large;
+  const loadTrashImages = appModeBase === "fishvtrash";
+  setState({dataSet, loadTrashImages});
+
   initFishData();
   await initRenderer();
 
-  const [appModeBase] = getAppMode(getState());
   let mode;
   if (appModeBase === 'instructions') {
     mode = Modes.Instructions;


### PR DESCRIPTION
App modes `fishvtrash` and `short` both work again now, relying on the app mode string set in the state at startup, and not on URL parameters.