### PR TITLE
Simple level progression UI on demo page

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,6 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>ML Activities Playground</title>
     <style>
+      #level-select {
+        height: 70px;
+        justify-content: center;
+        align-items: center;
+        display: flex;
+      }
       #container {
         position: relative;
         width: 100%;
@@ -49,6 +55,16 @@
     </style>
   </head>
   <body>
+    <div id="level-select">
+      <input type="radio" class="level-radio" name="level-radio" id="intro-instructions">
+      <input type="radio" class="level-radio" name="level-radio" id="fishvtrash-instructions">
+      <input type="radio" class="level-radio" name="level-radio" id="fishvtrash">
+      <input type="radio" class="level-radio" name="level-radio" id="creaturesvtrash">
+      <input type="radio" class="level-radio" name="level-radio" id="short-instructions">
+      <input type="radio" class="level-radio" name="level-radio" id="short">
+      <input type="radio" class="level-radio" name="level-radio" id="long">
+      <input type="radio" class="level-radio" name="level-radio" id="pondlab">
+    </div>
     <div id="container">
       <div id="container-react"></div>
       <canvas id="background-canvas"></canvas>

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -1,19 +1,23 @@
 import 'babel-polyfill';
 import $ from 'jquery';
-import ReactDOM from 'react-dom';
-import React from 'react';
-import UI from './ui';
-import constants, {Modes} from './constants';
-import {setInitialState, setSetStateCallback} from './state';
-import {render as renderCanvas} from './renderer';
 import {queryStrFor} from './helpers';
-import {toMode} from './toMode';
+import {initAll} from './init';
 
 let currentAppMode = queryStrFor('mode') || 'intro-instructions';
+let canvas, backgroundCanvas;
 
 function onLevelChange(event) {
   currentAppMode = event.target.id;
-  initAll(currentAppMode);
+  initDemoPage();
+}
+
+function initDemoPage() {
+  initAll({
+    appMode: currentAppMode,
+    onContinue,
+    canvas,
+    backgroundCanvas
+  });
 }
 
 function onContinue() {
@@ -29,44 +33,12 @@ function onContinue() {
 }
 
 $(document).ready(() => {
+  // Set up canvases.
+  canvas = document.getElementById('activity-canvas');
+  backgroundCanvas = document.getElementById('background-canvas');
+
   $(`#${currentAppMode}`).prop('checked', true);
   $('.level-radio').change(onLevelChange);
 
-  initAll(currentAppMode);
+  initDemoPage();
 });
-
-export const initAll = function(appMode) {
-  // Set up canvases.
-  const canvas = document.getElementById('activity-canvas');
-  const backgroundCanvas = document.getElementById('background-canvas');
-  canvas.width = backgroundCanvas.width = constants.canvasWidth;
-  canvas.height = backgroundCanvas.height = constants.canvasHeight;
-
-  // Set initial state for UI elements.
-  setInitialState({
-    appMode,
-    canvas,
-    backgroundCanvas,
-    currentMode: Modes.Loading,
-    onContinue
-  });
-
-  // Initialize our first model.
-  toMode(Modes.Loading);
-
-  // Start the canvas renderer.  It will self-perpetute by calling
-  // requestAnimationFrame on itself.
-  renderCanvas();
-
-  // Render the UI.
-  renderUI();
-
-  // And have the render UI handler be called every time state is set.
-  setSetStateCallback(renderUI);
-};
-
-// Tell React to explicitly render the UI.
-export const renderUI = () => {
-  const renderElement = document.getElementById('container-react');
-  ReactDOM.render(<UI />, renderElement);
-};

--- a/src/demo/index.jsx
+++ b/src/demo/index.jsx
@@ -4,26 +4,51 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 import UI from './ui';
 import constants, {Modes} from './constants';
-import {setState, setSetStateCallback} from './state';
+import {setInitialState, setSetStateCallback} from './state';
 import {render as renderCanvas} from './renderer';
 import {queryStrFor} from './helpers';
 import {toMode} from './toMode';
 
+let currentAppMode = queryStrFor('mode') || 'intro-instructions';
+
+function onLevelChange(event) {
+  currentAppMode = event.target.id;
+  initAll(currentAppMode);
+}
+
+function onContinue() {
+  const nextRadioButton = $(`#${currentAppMode}`).next();
+  if (nextRadioButton) {
+    nextRadioButton.prop('checked', true);
+    onLevelChange({
+      target: {
+        id: nextRadioButton.attr('id')
+      }
+    });
+  }
+}
+
 $(document).ready(() => {
+  $(`#${currentAppMode}`).prop('checked', true);
+  $('.level-radio').change(onLevelChange);
+
+  initAll(currentAppMode);
+});
+
+export const initAll = function(appMode) {
   // Set up canvases.
   const canvas = document.getElementById('activity-canvas');
   const backgroundCanvas = document.getElementById('background-canvas');
   canvas.width = backgroundCanvas.width = constants.canvasWidth;
   canvas.height = backgroundCanvas.height = constants.canvasHeight;
 
-  // Use URL parameter to set mode.
-  const appMode = queryStrFor('mode');
-
   // Set initial state for UI elements.
-  setState({
+  setInitialState({
     appMode,
     canvas,
-    backgroundCanvas
+    backgroundCanvas,
+    currentMode: Modes.Loading,
+    onContinue
   });
 
   // Initialize our first model.
@@ -38,7 +63,7 @@ $(document).ready(() => {
 
   // And have the render UI handler be called every time state is set.
   setSetStateCallback(renderUI);
-});
+};
 
 // Tell React to explicitly render the UI.
 export const renderUI = () => {

--- a/src/demo/init.js
+++ b/src/demo/init.js
@@ -1,0 +1,47 @@
+import 'idempotent-babel-polyfill';
+import ReactDOM from 'react-dom';
+import React from 'react';
+import UI from './ui';
+import constants, {Modes} from './constants';
+import {setInitialState, setSetStateCallback} from './state';
+import {render as renderCanvas} from './renderer';
+import {toMode} from './toMode';
+
+//
+// Required in options:
+//  canvas
+//  backgroundCanvas
+//  appMode
+//  onContinue
+//
+export const initAll = function(options) {
+  const { canvas, backgroundCanvas } = options;
+
+  canvas.width = backgroundCanvas.width = constants.canvasWidth;
+  canvas.height = backgroundCanvas.height = constants.canvasHeight;
+
+  // Set initial state for UI elements.
+  setInitialState({
+    currentMode: Modes.Loading,
+    ...options
+  });
+
+  // Initialize our first model.
+  toMode(Modes.Loading);
+
+  // Start the canvas renderer.  It will self-perpetute by calling
+  // requestAnimationFrame on itself.
+  renderCanvas();
+
+  // Render the UI.
+  renderUI();
+
+  // And have the render UI handler be called every time state is set.
+  setSetStateCallback(renderUI);
+};
+
+// Tell React to explicitly render the UI.
+function renderUI() {
+  const renderElement = document.getElementById('container-react');
+  ReactDOM.render(<UI />, renderElement);
+}

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -28,14 +28,22 @@ export const getState = function() {
 };
 
 export const setState = function(newState) {
-  state = {...state, ...newState};
+  return setStateInternal({...state, ...newState});
+};
+
+export const setInitialState = function(newState) {
+  return setStateInternal({...initialState, ...newState});
+};
+
+function setStateInternal(newState) {
+  state = newState;
 
   if (setStateCallback) {
     setStateCallback();
   }
 
   return state;
-};
+}
 
 export const setSetStateCallback = callback => {
   setStateCallback = callback;

--- a/src/index.js
+++ b/src/index.js
@@ -4,3 +4,4 @@ export {Modes} from './demo/constants';
 export * from './demo/state';
 export {render as renderCanvas} from './demo/renderer';
 export {default as UI} from './demo/ui';
+export {initAll} from './demo/init';


### PR DESCRIPTION
* Added basic UI in `ml-activities` demo page so you can run through an 8 level progression (the 3 video levels from the 11 level Code Studio script are not included here)
* Using the `?mode=short` URL syntax is still supported to set the initial level that will load
* We now export a new method call `initAll()`. The Code Studio side can get rid of a lot of code and just call this instead. For now, I'm exporting both the numerous methods and the new initAll(). Once we merge a Code Studio change (which I'm already testing locally), we can get rid of most of the exports from here.

<img width="1010" alt="Screen Shot 2019-11-04 at 10 38 06 AM" src="https://user-images.githubusercontent.com/5429146/68147643-53518100-feef-11e9-99b1-9353fb4240e7.png">
