### PR TITLE
make Continue advance instructions pages until on the last one

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -342,6 +342,21 @@ class Instructions extends React.Component {
     setState({currentInstructionsPage: page});
   }
 
+  onContinueButton = () => {
+    const state = getState();
+    const { onContinue, currentInstructionsPage } = state;
+    const [, appModeVariant] = getAppMode(state);
+    const numPages = instructionsText[appModeVariant].length;
+
+    if (currentInstructionsPage < numPages - 1) {
+      this.setInstructionsPage(currentInstructionsPage + 1);
+      return;
+    }
+    if (onContinue) {
+      onContinue();
+    }
+  };
+
   render() {
     const state = getState();
     const currentPage = state.currentInstructionsPage;
@@ -386,11 +401,7 @@ class Instructions extends React.Component {
         )}
         <Button
           style={styles.continueButton}
-          onClick={() => {
-            if (state.onContinue) {
-              state.onContinue();
-            }
-          }}
+          onClick={this.onContinueButton}
         >
           Continue
         </Button>


### PR DESCRIPTION
* When tapping Continue on an instructions page, we now advance you to the next page. Once you've seen all of the pages, then the Continue button will take you to the next level/bubble