### PR TITLE
Delayed appearances of some UI elements

### DIFF
--- a/src/demo/colors.js
+++ b/src/demo/colors.js
@@ -5,7 +5,7 @@ const colors = {
   green: '#56c568',
   red: '#eb5757',
   transparentBlack: 'rgba(0,0,0,0.5)',
-  transparentWhite: 'rgba(255,255,255,0.5)'
+  transparentWhite: 'rgba(255,255,255,0.8)'
 };
 
 export default colors;

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -75,6 +75,8 @@ export const render = () => {
 
   clearCanvas(state.canvas);
 
+  const timeBeforeCanSkipPredict = 5000;
+
   switch (state.currentMode) {
     case Modes.Training:
       drawFrame(state);
@@ -83,6 +85,14 @@ export const render = () => {
     case Modes.Predicting:
       drawPredictBot(state);
       drawMovingFish(state);
+
+      if (state.isRunning) {
+        setState({
+          canSkipPredict:
+            $time() >= state.runStartTime + timeBeforeCanSkipPredict
+        });
+      }
+
       break;
     case Modes.Pond:
       drawPondFishImages();

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -76,6 +76,8 @@ export const render = () => {
   clearCanvas(state.canvas);
 
   const timeBeforeCanSkipPredict = 5000;
+  const timeBeforeCanSeePondText = 3000;
+  const timeBeforeCanSkipPond = 5000;
 
   switch (state.currentMode) {
     case Modes.Training:
@@ -96,6 +98,13 @@ export const render = () => {
       break;
     case Modes.Pond:
       drawPondFishImages();
+
+      setState({
+        canSkipPond:
+          $time() >= currentModeStartTime + timeBeforeCanSkipPond,
+        canSeePondText:
+          $time() >= currentModeStartTime + timeBeforeCanSeePondText
+      });
       break;
   }
 

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -15,6 +15,8 @@ const initialState = {
   isRunning: false,
   runStartTime: null,
   canSkipPredict: null,
+  canSeePondText: null,
+  canSkipPond: null,
   yesCount: 0,
   noCount: 0,
   loadTrashImages: null,

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -13,6 +13,8 @@ const initialState = {
   trainingIndex: 0,
   iterationCount: 0,
   isRunning: false,
+  runStartTime: null,
+  canSkipPredict: null,
   yesCount: 0,
   noCount: 0,
   loadTrashImages: null,

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -150,16 +150,18 @@ const styles = {
   },
   pondText: {
     position: 'absolute',
-    bottom: '3%',
-    left: '45%',
+    bottom: '4%',
+    left: '43%',
     transform: 'translateX(-45%)',
-    fontSize: 22,
+    fontSize: 18,
     lineHeight: '32px',
+    textAlign: 'center',
     width: '50%',
-    backgroundColor: colors.transparentBlack,
-    padding: '2%',
+    backgroundColor: colors.transparentWhite,
+    border: '4px solid black',
+    padding: '1%',
     borderRadius: 10,
-    color: colors.white
+    color: colors.black
   },
   pondFishDetails: {
     position: 'absolute',
@@ -678,11 +680,13 @@ class Pond extends React.Component {
 
   render() {
     const state = getState();
-    const pondText = `Out of ${
-      state.fishData.length
-    } objects, A.I. identified ${
-      state.pondFish.length
-    } that it classified as ${state.word.toUpperCase()}.`;
+    const pondText = [
+      `Out of ${state.fishData.length} objects, I identified ${
+        state.pondFish.length
+      } that are ${state.word.toUpperCase()}.`,
+      'How did I do?',
+      'Choose to Train More or Continue.'
+    ];
 
     const showFishDetails = !!state.pondClickedFish;
     let pondFishDetailsStyle;
@@ -719,9 +723,15 @@ class Pond extends React.Component {
     return (
       <Body onClick={this.onPondClick}>
         <Header>A.I. Results</Header>
-        {state.canSeePondText && (
-          <div style={styles.pondText}>{pondText}</div>
-        )}
+        {state.canSeePondText && <div style={styles.pondText}>
+          {pondText.map((text, index) => {
+            return (
+              <div>
+                {text}
+              </div>
+            );
+          })}
+        </div>}
         <img style={styles.pondBot} src={aiBotClosed} />
         {showFishDetails && (
           <div style={pondFishDetailsStyle}>{confidence}</div>

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -230,6 +230,12 @@ function Collide(x1, y1, w1, h1, x2, y2, w2, h2) {
   return true;
 }
 
+var $time =
+  Date.now ||
+  function() {
+    return +new Date();
+  };
+
 class Body extends React.Component {
   static propTypes = {
     children: PropTypes.node,
@@ -528,8 +534,10 @@ let Train = class Train extends React.Component {
     const trainQuestionTextStyle = state.isRunning
       ? styles.trainQuestionTextDisabled
       : styles.trainQuestionText;
-    const yesButtonText = state.appMode === 'creaturesvtrash' ? 'Yes' : state.word;
-    const noButtonText = state.appMode === 'creaturesvtrash' ? 'No' : `Not ${state.word}`;
+    const yesButtonText =
+      state.appMode === 'creaturesvtrash' ? 'Yes' : state.word;
+    const noButtonText =
+      state.appMode === 'creaturesvtrash' ? 'No' : `Not ${state.word}`;
     return (
       <Body>
         <Header>A.I. Training</Header>
@@ -591,24 +599,28 @@ class Predict extends React.Component {
     const state = getState();
     const speechBubbleText = this.speechBubbleText(state);
 
-    let btnText, btnOnClick;
-    if (state.isRunning) {
-      btnText = 'Continue';
-      btnOnClick = () => toMode(Modes.Pond);
-    } else {
-      btnText = 'Run A.I.';
-      btnOnClick = () => setState({isRunning: true});
-    }
-
     return (
       <Body>
         <Header>A.I. Sorting</Header>
         {speechBubbleText && (
           <SpeechBubble text={speechBubbleText} style={styles.predictSpeech} />
         )}
-        <Button style={styles.continueButton} onClick={btnOnClick}>
-          {btnText}
-        </Button>
+        {!state.isRunning && (
+          <Button
+            style={styles.continueButton}
+            onClick={() => setState({isRunning: true, runStartTime: $time()})}
+          >
+            Run A.I.
+          </Button>
+        )}
+        {state.canSkipPredict && (
+          <Button
+            style={styles.continueButton}
+            onClick={() => toMode(Modes.Pond)}
+          >
+            Continue
+          </Button>
+        )}
       </Body>
     );
   }
@@ -631,7 +643,8 @@ class Pond extends React.Component {
         if (
           !fishClicked &&
           !(
-            state.pondClickedFish && fishBound.fishId === state.pondClickedFish.id
+            state.pondClickedFish &&
+            fishBound.fishId === state.pondClickedFish.id
           ) &&
           Collide(
             fishBound.x,

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -719,21 +719,25 @@ class Pond extends React.Component {
     return (
       <Body onClick={this.onPondClick}>
         <Header>A.I. Results</Header>
-        <div style={styles.pondText}>{pondText}</div>
+        {state.canSeePondText && (
+          <div style={styles.pondText}>{pondText}</div>
+        )}
         <img style={styles.pondBot} src={aiBotClosed} />
         {showFishDetails && (
           <div style={pondFishDetailsStyle}>{confidence}</div>
         )}
-        <Button
-          style={styles.continueButton}
-          onClick={() => {
-            if (state.onContinue) {
-              state.onContinue();
-            }
-          }}
-        >
-          Continue
-        </Button>
+        {state.canSkipPond && (
+          <Button
+            style={styles.continueButton}
+            onClick={() => {
+              if (state.onContinue) {
+                state.onContinue();
+              }
+            }}
+          >
+            Continue
+          </Button>
+        )}
       </Body>
     );
   }

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -706,13 +706,13 @@ class Pond extends React.Component {
       };
 
       if (!fish.confidence || !fish.confidence.confidencesByClassId) {
-        confidence = 'Not sure';
+        confidence = 'Not confident';
       } else if (fish.confidence.confidencesByClassId[0] > 0.99) {
-        confidence = 'Very sure';
+        confidence = 'Very confident';
       } else if (fish.confidence.confidencesByClassId[0] > 0.5) {
-        confidence = 'Fairly sure';
+        confidence = 'Fairly confident';
       } else {
-        confidence = 'Not very sure';
+        confidence = 'Not very confident';
       }
     }
 


### PR DESCRIPTION
- The appearance of the Continue button on the sorting scene is now delayed again.  Followup to #144
- Confidence text now refers to "confident" rather than "sure"
- Delay the appearance of pond text & pond "Continue" button
- Update pond text

![Screenshot 2019-11-05 09 33 28](https://user-images.githubusercontent.com/2205926/68231145-5744d800-ffaf-11e9-8d77-1d2d4dc17302.png)
![Screenshot 2019-11-05 09 27 58](https://user-images.githubusercontent.com/2205926/68231146-5744d800-ffaf-11e9-8416-de9766a361e3.png)
