### PR TITLE
Reduce the variety of sea creatures for the bias demo and reduce the …

### DIFF
--- a/src/demo/OceanObject.js
+++ b/src/demo/OceanObject.js
@@ -82,12 +82,19 @@ export const loadAllTrashImages = () => {
 
 // Load all of the sea creature assets and store them
 export const loadAllSeaCreatureImages = () => {
-  const loadImagePromises = seaCreatureImagePaths.map((src, idx) => {
-    return loadImage({src, idx});
+  const loadImagePromises = seaCreatureImagePaths.map((seaCreature, idx) => {
+    return loadImage({
+      src: seaCreature.src,
+      exclusions: seaCreature.exclusions,
+      idx
+    });
   });
   return Promise.all(loadImagePromises).then(results => {
     results.forEach(result => {
-      seaCreatureImages[result.data.idx] = result.img;
+      seaCreatureImages[result.data.idx] = {
+        image: result.img,
+        exclusions: result.data.exclusions
+      };
     });
   });
 };
@@ -356,9 +363,12 @@ export class TrashOceanObject extends OceanObject {
  *
  * */
 export class SeaCreatureOceanObject extends OceanObject {
-  randomize() {
-    const idx = Math.floor(Math.random() * seaCreatureImages.length);
-    this.image = seaCreatureImages[idx];
+  randomize(exclusions) {
+    const possibleSeaCreatures = seaCreatureImages.filter(
+      seaCreature => !seaCreature.exclusions.includes(exclusions)
+    );
+    const idx = Math.floor(Math.random() * possibleSeaCreatures.length);
+    this.image = possibleSeaCreatures[idx].image;
   }
 
   drawToCanvas(canvas, generateLogits = true) {

--- a/src/demo/models/predict.js
+++ b/src/demo/models/predict.js
@@ -4,7 +4,9 @@ import {generateOcean} from '../../utils/generateOcean';
 
 export const init = () => {
   const state = getState();
-  const fishData = generateOcean(100, state.loadTrashImages);
+  setState({loadCreatureImages: true})
+  const numFish = state.appMode === 'creaturesvtrashdemo' ? 30 : 100;
+  const fishData = generateOcean(numFish);
   setState({fishData});
 };
 

--- a/src/demo/models/predict.js
+++ b/src/demo/models/predict.js
@@ -4,7 +4,6 @@ import {generateOcean} from '../../utils/generateOcean';
 
 export const init = () => {
   const state = getState();
-  setState({loadCreatureImages: true})
   const numFish = state.appMode === 'creaturesvtrashdemo' ? 30 : 100;
   const fishData = generateOcean(numFish);
   setState({fishData});

--- a/src/utils/generateOcean.js
+++ b/src/utils/generateOcean.js
@@ -37,8 +37,9 @@ export const generateOcean = numFish => {
   mouths = _.shuffle(mouths);
   let colorPalettes = Object.values(possibleFishComponents.colorPalettes);
   colorPalettes = _.shuffle(colorPalettes);
+  const exclusions = state.appMode === 'creaturesvtrashdemo' ? 'biasDemo' : state.dataSet;
   for (var i = 0; i < numFish; ++i) {
-    const object = new possibleObjects[i % possibleObjects.length](i);
+    const object = new possibleObjects[i % possibleObjects.length](i, possibleFishComponents);
     if (object instanceof FishOceanObject) {
       // For each of these components, use the next variation on the list
       // Reshuffle the list if we've reached the end to avoid any regularity.
@@ -60,7 +61,7 @@ export const generateOcean = numFish => {
       colorPalettes = _.shuffle(colorPalettes);
     }
 
-    object.randomize();
+    object.randomize(exclusions);
     ocean.push(object);
   }
   ocean = _.shuffle(ocean);

--- a/src/utils/imagePaths.js
+++ b/src/utils/imagePaths.js
@@ -30,12 +30,12 @@ export const trashImagePaths = [
 ];
 
 export const seaCreatureImagePaths = [
-  Crab,
-  Jellyfish,
-  Octopus,
-  Seahorse,
-  Snail,
-  Starfish,
-  Turtle,
-  Whale
+  {src: Crab, exclusions: ['biasDemo']},
+  {src: Jellyfish, exclusions: []},
+  {src: Octopus, exclusions: ['biasDemo']},
+  {src: Seahorse, exclusions: []},
+  {src: Snail, exclusions: ['biasDemo']},
+  {src: Starfish, exclusions: ['biasDemo']},
+  {src: Turtle, exclusions: ['biasDemo']},
+  {src: Whale, exclusions: []},
 ];


### PR DESCRIPTION
…number of objects we generate.

I'm currently only including sea creatures that seem to be trash frequently and because the set is only 30 objects, the students are guaranteed to see a sea creature on or before the 21st object (the types are evenly distributed).

Also fixed a bug where I apparently removed the `possibleFishComponents` argument to the constructor of `OceanObject`. This just affects fins for the short word list.

I'd appreciate this PR being pulled and tested locally as it's kind of a mess. We need to clean up this logic after the playtest.