### PR TITLE
Always re-generate ocean + set trainingIndex to 0

### DIFF
--- a/src/demo/models/train.js
+++ b/src/demo/models/train.js
@@ -7,11 +7,6 @@ import {generateOcean} from '../../utils/generateOcean';
 export const init = () => {
   const state = getState();
 
-  let fishData = [...state.fishData];
-  if (fishData.length === 0) {
-    fishData = fishData.concat(generateOcean(100));
-  }
-
   let trainer = state.trainer;
   if (!trainer) {
     trainer = new SimpleTrainer();
@@ -32,7 +27,8 @@ export const init = () => {
   }
 
   setState({
-    fishData,
+    fishData: generateOcean(100),
+    trainingIndex: 0,
     trainer,
     isRunning: true
   });


### PR DESCRIPTION
**Work item:** When selecting ‘Train More’, after the 2nd iteration the labeling buttons no longer work and the fish parade stops flowing.

This was actually a pretty bad bug that was contributing to the inaccuracy of our model's predictions.

In our `train.js` model, we...
- weren't re-setting `state.trainingIndex` to 0
- were only re-generating an ocean if we didn't already have one present

We should be doing both of those things every time we initialize the training model. I noticed an immediate increase in the model's predictions upon making this change.

The bug manifested as an "index out of range" error as the trainingIndex would eventually be greater than the length of `state.fishData`.