### PR TITLE
Guide improvements

### DIFF
--- a/src/demo/models/guide.js
+++ b/src/demo/models/guide.js
@@ -260,7 +260,7 @@ const guides = [
     when: {appMode: AppMode.FishLong, currentMode: Modes.Pond},
     style: 'BottomMiddle',
     arrow: 'none'
-  },
+  }
 ];
 
 export function getCurrentGuide() {
@@ -290,7 +290,9 @@ export function getCurrentGuide() {
 export function dismissCurrentGuide() {
   const currentGuide = getCurrentGuide();
 
-  if (currentGuide) {
+  // If we have a current guide, and it's actually showing (rather than still
+  // typing).
+  if (currentGuide && getState().guideShowing) {
     const state = getState();
     const currentGuideDismissals = state.guideDismissals;
     let newGuideDismissals = [...currentGuideDismissals];

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -435,7 +435,7 @@ const drawPondFishImages = () => {
       h: constants.fishCanvasHeight / 2,
       confidence: fish.result
     });
-    setState({pondFishBounds: fishBounds});
+    setState({pondFishBounds: fishBounds}, {skipCallback: true});
   });
 };
 

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -34,18 +34,18 @@ export const getState = function() {
   return state;
 };
 
-export const setState = function(newState) {
-  return setStateInternal({...state, ...newState});
+export const setState = function(newState, options = null) {
+  return setStateInternal({...state, ...newState}, options);
 };
 
 export const setInitialState = function(newState) {
   return setStateInternal({...initialState, ...newState});
 };
 
-function setStateInternal(newState) {
+function setStateInternal(newState, options = null) {
   state = newState;
 
-  if (setStateCallback) {
+  if (setStateCallback && !(options && options.skipCallback)) {
     setStateCallback();
   }
 

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -214,9 +214,19 @@ const styles = {
     position: 'absolute',
     backgroundColor: colors.black,
     color: colors.white,
-    padding: 15,
     textAlign: 'center',
     lineHeight: '140%'
+  },
+  guideTypingText: {
+    position: 'absolute',
+    padding: 15
+  },
+  guideFinalText: {
+    padding: 15,
+    color: colors.white,
+    textAlign: 'center',
+    lineHeight: '140%',
+    opacity: 0
   },
   guideBackground: {
     backgroundColor: 'rgba(0,0,0,0.3)',
@@ -254,7 +264,7 @@ const styles = {
     left: '5%'
   },
   guideBottomMiddle: {
-    bottom: '10%',
+    bottom: 10,
     left: '50%',
     transform: 'translateX(-50%)'
   },
@@ -803,16 +813,23 @@ class Guide extends React.Component {
             <div
               style={{...styles.guide, ...styles[`guide${currentGuide.style}`]}}
             >
-              <Typist
-                avgTypingDelay={35}
-                stdTypingDelay={15}
-                cursor={{show: false}}
-                onTypingDone={this.onShowing}
-              >
+              <div style={styles.guideTypingText}>
+                <Typist
+                  avgTypingDelay={35}
+                  stdTypingDelay={15}
+                  cursor={{show: false}}
+                  onTypingDone={this.onShowing}
+                >
+                  {currentGuide.textFn
+                    ? currentGuide.textFn(getState())
+                    : currentGuide.text}
+                </Typist>
+              </div>
+              <div style={styles.guideFinalText}>
                 {currentGuide.textFn
                   ? currentGuide.textFn(getState())
                   : currentGuide.text}
-              </Typist>
+              </div>
               {getState().guideShowing && currentGuide.arrow !== 'none' && (
                 <div>
                   <div style={styles.guideArrow}> </div>


### PR DESCRIPTION
- Wait until typing is finished before Guide can be dismissed.
- Pre-size the Guide to fit the final text.  (The text still wraps as it types in some cases, though, which is not quite perfect.)
- Fix framerate drop on the pond by not attempting to re-render React UI at 60fps.