### PR TITLE
fix cropping issue by adding when fn

### DIFF
--- a/src/demo/models/guide.js
+++ b/src/demo/models/guide.js
@@ -62,7 +62,13 @@ const guides = [
         state.totalPondFish
       } that belong in water.`;
     },
-    when: {appMode: AppMode.FishVTrash, currentMode: Modes.Pond},
+    when: {
+      appMode: AppMode.FishVTrash,
+      currentMode: Modes.Pond,
+      fn: state => {
+        return state.fishData && state.totalPondFish !== null;
+      }
+    },
     style: 'BottomMiddle',
     arrow: 'none'
   },
@@ -176,7 +182,13 @@ const guides = [
         state.totalPondFish
       } that belong in water.`;
     },
-    when: {appMode: AppMode.CreaturesVTrash, currentMode: Modes.Pond},
+    when: {
+      appMode: AppMode.CreaturesVTrash,
+      currentMode: Modes.Pond,
+      fn: state => {
+        return state.fishData && state.totalPondFish !== null;
+      }
+    },
     style: 'BottomMiddle',
     arrow: 'none'
   },
@@ -213,7 +225,13 @@ const guides = [
         state.totalPondFish
       } that are ${state.word.toLowerCase()}.`;
     },
-    when: {appMode: AppMode.FishShort, currentMode: Modes.Pond},
+    when: {
+      appMode: AppMode.FishShort,
+      currentMode: Modes.Pond,
+      fn: state => {
+        return state.fishData && state.totalPondFish !== null;
+      }
+    },
     style: 'BottomMiddle',
     arrow: 'none'
   },
@@ -250,7 +268,13 @@ const guides = [
         state.totalPondFish
       } that are ${state.word.toLowerCase()}.`;
     },
-    when: {appMode: AppMode.FishLong, currentMode: Modes.Pond},
+    when: {
+      appMode: AppMode.FishLong,
+      currentMode: Modes.Pond,
+      fn: state => {
+        return state.fishData && state.totalPondFish !== null;
+      }
+    },
     style: 'BottomMiddle',
     arrow: 'none'
   },


### PR DESCRIPTION
* The `Typist` component doesn't handle having its children text node change. Since the `totalPondFish` is `null` for a little while, it means we were first starting with one text node string (containing `null`) and then later adjusting it with a different text node string (containing the proper number of total pond fish). However, it continued to display the string containing `null`
* Fixed by adding a `when` `fn` for these guides - to ensure that our state is initialized to the point where we know `totalPondFish` before we render the `Typist` piece. 