### PR TITLE
Actually continue when pressing the continue button

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -807,7 +807,7 @@ class Pond extends React.Component {
             ) : (
               <Button
                 style={styles.continueButton}
-                onClick={() => toMode(Modes.Predicting)}
+                onClick={() => state.onContinue()}
               >
                 Continue
               </Button>


### PR DESCRIPTION
#222 accidentally replaced the behaviour of clicking `Continue` to get back to the predicting screen instead of continuing.