### PR TITLE
Add recall fish

### DIFF
--- a/src/demo/colors.js
+++ b/src/demo/colors.js
@@ -1,7 +1,7 @@
 const colors = {
   white: 'white',
   black: 'black',
-  grey: 'grey',
+  grey: '#4d575f',
   darkGrey: '#2f353e',
   lightGrey: '#e7e7e7',
   green: '#56c568',

--- a/src/demo/models/pond.js
+++ b/src/demo/models/pond.js
@@ -39,7 +39,7 @@ const predictAllFish = state => {
   });
 };
 
-const arrangeFish = fishes => {
+export const arrangeFish = fishes => {
   let fishPositions = formatArrangement();
 
   fishes.forEach(fish => {

--- a/src/demo/models/pond.js
+++ b/src/demo/models/pond.js
@@ -6,14 +6,21 @@ import constants, {ClassType} from '../constants';
 export const init = async () => {
   const state = getState();
   let fishWithConfidence = await predictAllFish(state);
-  setState({totalPondFish: fishWithConfidence.length});
   fishWithConfidence = _.sortBy(fishWithConfidence, ['confidence']);
-  const pondFishWithConfidence = fishWithConfidence.splice(
+  const fishByClassType = _.groupBy(
+    fishWithConfidence,
+    fish => fish.getResult().predictedClassId
+  );
+
+  let pondFish = fishByClassType[ClassType.Like];
+  setState({totalPondFish: pondFish.length});
+  pondFish = pondFish.splice(0, constants.maxPondFish);
+  const recallFish = fishByClassType[ClassType.Dislike].splice(
     0,
     constants.maxPondFish
   );
-  arrangeFish(pondFishWithConfidence);
-  setState({pondFish: pondFishWithConfidence});
+  arrangeFish(pondFish);
+  setState({pondFish, recallFish});
 };
 
 const predictAllFish = state => {
@@ -21,10 +28,8 @@ const predictAllFish = state => {
     let fishWithConfidence = [];
     state.fishData.map((fish, index) => {
       state.trainer.predict(fish).then(res => {
-        if (res.predictedClassId === ClassType.Like) {
-          fish.setResult(res);
-          fishWithConfidence.push(fish);
-        }
+        fish.setResult(res);
+        fishWithConfidence.push(fish);
 
         if (index === state.fishData.length - 1) {
           resolve(fishWithConfidence);

--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -495,12 +495,12 @@ const drawPredictBot = state => {
 
 // Draw the fish for pond mode.
 const drawPondFishImages = () => {
-  const canvas = getState().canvas;
-  const ctx = canvas.getContext('2d');
-
+  const state = getState();
+  const ctx = state.canvas.getContext('2d');
+  const fishes = state.showRecallFish ? state.recallFish : state.pondFish;
   const fishBounds = [];
 
-  getState().pondFish.forEach(fish => {
+  fishes.forEach(fish => {
     const pondClickedFish = getState().pondClickedFish;
     const pondClickedFishUs = pondClickedFish && fish.id === pondClickedFish.id;
 

--- a/src/demo/state.js
+++ b/src/demo/state.js
@@ -5,6 +5,8 @@ const initialState = {
   currentMode: null,
   fishData: [],
   pondFish: [],
+  recallFish: [],
+  showRecallFish: false,
   totalPondFish: null,
   backgroundCanvas: null,
   canvas: null,

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -894,7 +894,7 @@ let Pond = class Pond extends React.Component {
     const fish = showRecallFish ? state.recallFish : state.pondFish;
 
     // Don't call arrangeFish if fish have already been arranged.
-    if (!fish[0].getXY()) {
+    if (fish.length > 0 && !fish[0].getXY()) {
       arrangeFish(fish);
     }
 

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -45,6 +45,7 @@ const styles = {
   button: {
     cursor: 'pointer',
     backgroundColor: colors.white,
+    color: colors.grey,
     borderRadius: 8,
     minWidth: 160,
     outline: 'none',

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -299,15 +299,6 @@ const styles = {
     transform: 'translateX(-45%)',
     pointerEvents: 'none'
   },
-  recallButton: {
-    position: 'absolute',
-    top: '4%',
-    left: '2.25%',
-    minWidth: 175,
-    ':focus': {
-      outline: 'none'
-    }
-  },
   recallContainer: {
     position: 'absolute',
     top: '4%',

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -7,6 +7,7 @@ import constants, {AppMode, Modes} from './constants';
 import {toMode} from './toMode';
 import {$time, currentRunTime, finishMovement, resetTraining} from './helpers';
 import {onClassifyFish} from './models/train';
+import {arrangeFish} from './models/pond';
 import colors from './colors';
 import aiBotClosed from '../../public/images/ai-bot/ai-bot-closed.png';
 import counterIcon from '../../public/images/data.png';
@@ -927,6 +928,15 @@ class Pond extends React.Component {
 
     return (
       <Body onClick={e => this.onPondClick(e)}>
+        <Button
+          onClick={() => {
+            let showRecallFish = !state.showRecallFish;
+            arrangeFish(showRecallFish ? state.recallFish : state.pondFish);
+            setState({showRecallFish});
+          }}
+        >
+          Recall
+        </Button>
         <img style={styles.pondBot} src={aiBotClosed} />
         {state.canSkipPond && (
           <div>

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -13,8 +13,6 @@ import aiBotClosed from '../../public/images/ai-bot/ai-bot-closed.png';
 import counterIcon from '../../public/images/data.png';
 import eraseButton from '../../public/images/erase.png';
 import arrowDownImage from '../../public/images/arrow-down.png';
-import banIcon from '../../public/images/ban-icon.png';
-import checkmarkIcon from '../../public/images/checkmark-icon.png';
 import snail from '../../public/images/seaCreatures/Snail.png';
 import Typist from 'react-typist';
 import {getCurrentGuide, dismissCurrentGuide} from './models/guide';
@@ -25,7 +23,9 @@ import {
   faPause,
   faBackward,
   faForward,
-  faEraser
+  faEraser,
+  faCheck,
+  faBan
 } from '@fortawesome/free-solid-svg-icons';
 
 const styles = {
@@ -309,14 +309,28 @@ const styles = {
     }
   },
   recallContainer: {
+    position: 'absolute',
+    top: '4%',
+    right: '2.25%',
+    color: colors.white,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between'
   },
   recallIcon: {
-    width: 24,
-    height: 24,
-    marginRight: 10
+    width: 30,
+    height: 30,
+    border: `5px solid ${colors.white}`,
+    borderRadius: 50,
+    padding: 6,
+    marginLeft: 8,
+    backgroundColor: colors.lightGrey
+  },
+  bgRed: {
+    backgroundColor: colors.red
+  },
+  bgGreen: {
+    backgroundColor: colors.green
   },
   pill: {
     display: 'flex',
@@ -878,7 +892,7 @@ let Predict = class Predict extends React.Component {
 };
 Predict = Radium(Predict);
 
-class Pond extends React.Component {
+let Pond = class Pond extends React.Component {
   constructor(props) {
     super(props);
   }
@@ -963,20 +977,25 @@ class Pond extends React.Component {
 
     return (
       <Body onClick={this.onPondClick}>
-        <Button onClick={this.toggleRecall} style={styles.recallButton}>
-          {state.showRecallFish && (
-            <span style={styles.recallContainer}>
-              <img src={banIcon} style={styles.recallIcon} />
-              <span>{`Not ${state.word}`}</span>
-            </span>
-          )}
-          {!state.showRecallFish && (
-            <span style={styles.recallContainer}>
-              <img src={checkmarkIcon} style={styles.recallIcon} />
-              <span>{state.word}</span>
-            </span>
-          )}
-        </Button>
+        <div style={styles.recallContainer}>
+          Show
+          <FontAwesomeIcon
+            icon={faCheck}
+            style={{
+              ...styles.recallIcon,
+              ...(!state.showRecallFish ? styles.bgGreen : {})
+            }}
+            onClick={this.toggleRecall}
+          />
+          <FontAwesomeIcon
+            icon={faBan}
+            style={{
+              ...styles.recallIcon,
+              ...(state.showRecallFish ? styles.bgRed : {})
+            }}
+            onClick={this.toggleRecall}
+          />
+        </div>
         <img style={styles.pondBot} src={aiBotClosed} />
         {state.canSkipPond && (
           <div>
@@ -1021,7 +1040,8 @@ class Pond extends React.Component {
       </Body>
     );
   }
-}
+};
+Pond = Radium(Pond);
 
 class Guide extends React.Component {
   onShowing() {

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -927,7 +927,7 @@ class Pond extends React.Component {
     const state = getState();
 
     return (
-      <Body onClick={e => this.onPondClick(e)}>
+      <Body onClick={this.onPondClick}>
         <Button
           onClick={() => {
             let showRecallFish = !state.showRecallFish;

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -861,7 +861,20 @@ class Pond extends React.Component {
     super(props);
   }
 
-  onPondClick(e) {
+  toggleRecall = () => {
+    const state = getState();
+    const showRecallFish = !state.showRecallFish;
+    const fish = showRecallFish ? state.recallFish : state.pondFish;
+
+    // Don't call arrangeFish if fish have already been arranged.
+    if (!fish[0].getXY()) {
+      arrangeFish(fish);
+    }
+
+    setState({showRecallFish});
+  };
+
+  onPondClick = e => {
     // Don't allow pond clicks if a Guide is currently showing.
     if (getCurrentGuide()) {
       return;
@@ -921,22 +934,14 @@ class Pond extends React.Component {
         playSound('no');
       }
     }
-  }
+  };
 
   render() {
     const state = getState();
 
     return (
       <Body onClick={this.onPondClick}>
-        <Button
-          onClick={() => {
-            let showRecallFish = !state.showRecallFish;
-            arrangeFish(showRecallFish ? state.recallFish : state.pondFish);
-            setState({showRecallFish});
-          }}
-        >
-          Recall
-        </Button>
+        <Button onClick={this.toggleRecall}>Recall</Button>
         <img style={styles.pondBot} src={aiBotClosed} />
         {state.canSkipPond && (
           <div>

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -13,6 +13,8 @@ import aiBotClosed from '../../public/images/ai-bot/ai-bot-closed.png';
 import counterIcon from '../../public/images/data.png';
 import eraseButton from '../../public/images/erase.png';
 import arrowDownImage from '../../public/images/arrow-down.png';
+import banIcon from '../../public/images/ban-icon.png';
+import checkmarkIcon from '../../public/images/checkmark-icon.png';
 import snail from '../../public/images/seaCreatures/Snail.png';
 import Typist from 'react-typist';
 import {getCurrentGuide, dismissCurrentGuide} from './models/guide';
@@ -295,6 +297,25 @@ const styles = {
     bottom: 0,
     transform: 'translateX(-45%)',
     pointerEvents: 'none'
+  },
+  recallButton: {
+    position: 'absolute',
+    top: '4%',
+    left: '2.25%',
+    minWidth: 175,
+    ':focus': {
+      outline: 'none'
+    }
+  },
+  recallContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between'
+  },
+  recallIcon: {
+    width: 24,
+    height: 24,
+    marginRight: 10
   },
   pill: {
     display: 'flex',
@@ -941,7 +962,20 @@ class Pond extends React.Component {
 
     return (
       <Body onClick={this.onPondClick}>
-        <Button onClick={this.toggleRecall}>Recall</Button>
+        <Button onClick={this.toggleRecall} style={styles.recallButton}>
+          {state.showRecallFish && (
+            <span style={styles.recallContainer}>
+              <img src={banIcon} style={styles.recallIcon} />
+              <span>{`Not ${state.word}`}</span>
+            </span>
+          )}
+          {!state.showRecallFish && (
+            <span style={styles.recallContainer}>
+              <img src={checkmarkIcon} style={styles.recallIcon} />
+              <span>{state.word}</span>
+            </span>
+          )}
+        </Button>
         <img style={styles.pondBot} src={aiBotClosed} />
         {state.canSkipPond && (
           <div>


### PR DESCRIPTION
[Video](https://drive.google.com/file/d/1CgK7cu8zZ1o2dabAwsgBX4TDzqUO6NWg/view?usp=sharing)

Before, we only showed the "top" 20 fish (fish classified as `ClassType.Like` with the highest confidence). Now, there are buttons to let you toggle between the "top" and "bottom" 20 (bottom == fish classified as `ClassType.Dislike` with the highest confidence).

**Up next:** Add a transition when you toggle between these states.

**Screenshots:**

![Screen Shot 2019-11-22 at 12 59 07 PM](https://user-images.githubusercontent.com/9812299/69460005-e5e38400-0d27-11ea-9560-d82b4118ffc1.png)

![Screen Shot 2019-11-22 at 12 59 10 PM](https://user-images.githubusercontent.com/9812299/69460004-e5e38400-0d27-11ea-9e72-14d99aea6cf9.png)