### PR TITLE
Pond: Quick fix to handle no fish in a pond

### DIFF
--- a/src/demo/models/pond.js
+++ b/src/demo/models/pond.js
@@ -12,10 +12,10 @@ export const init = async () => {
     fish => fish.getResult().predictedClassId
   );
 
-  let pondFish = fishByClassType[ClassType.Like];
+  let pondFish = fishByClassType[ClassType.Like] || [];
   setState({totalPondFish: pondFish.length});
   pondFish = pondFish.splice(0, constants.maxPondFish);
-  const recallFish = fishByClassType[ClassType.Dislike].splice(
+  const recallFish = (fishByClassType[ClassType.Dislike] || []).splice(
     0,
     constants.maxPondFish
   );


### PR DESCRIPTION
This fixes errors where no fish appear in either the "like" pond or the "dislike" pond.