### PR TITLE
Pond: Fix missing fish

### DIFF
--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -66,6 +66,12 @@ export const initRenderer = () => {
 // Render a single frame of the scene.
 // Sometimes performs special rendering actions, such as when mode has changed.
 export const render = () => {
+  // Set up the next call to the renderer.  One advantage of doing it here is
+  // that if any exceptions occur, we will have still scheduled the next render.
+  // Otherwise, any exception that occurs would prevent any more renders from
+  // happening.
+  window.requestAnimFrame(render);
+
   let state = getState();
 
   if (state.currentMode !== prevState.currentMode) {
@@ -150,7 +156,6 @@ export const render = () => {
   drawOverlays();
 
   prevState = {...state};
-  window.requestAnimFrame(render);
 };
 
 // Load and display the background image onto the background canvas.

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -853,6 +853,7 @@ let Predict = class Predict extends React.Component {
     if (state.appMode === AppMode.CreaturesVTrashDemo && state.onContinue) {
       state.onContinue();
     } else {
+      setState({showRecallFish: false});
       toMode(Modes.Pond);
     }
   };


### PR DESCRIPTION
@uponthesun  encountered a situation in which fish had stopped rendering.  By reviewing the console logs we were able to guess at a repro, then repro, and ultimately make this fix.

The first issue discovered was that when the renderer encountered an exception, it never scheduled the next render.  A simple fix here is to schedule the next render before doing anything else.

The repro was entering the pond, toggling to show the disliked fish, then training more, then returning to the pond.  The renderer tried to render the disliked fish, but none of them had XY coordinates yet, because we don't arrange those fish until the user explicitly toggles to show them.  The simple fix is to always set the state to show liked fish when entering the pond.

Recent features additions such as the pond toggling and the ability to loop through the app (both training more, and starting over) mean we have a lot more state to deal with, and the global scope of all our state means we have more opportunity to get into unexpected situations.