### PR TITLE
Final responsive work (hopefully)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,6 +11,10 @@
         align-items: center;
         display: flex;
       }
+      input[type="radio"] {
+        cursor: pointer;
+      }
+
       #container {
         position: relative;
         width: 100%;
@@ -26,6 +30,7 @@
         user-select: none;
         font-family: arial, sans-serif;
         font-size: 18px;
+        line-height: 1.3;
         color: rgb(30, 30, 30);
       }
       #background-canvas {
@@ -41,72 +46,26 @@
         border: none;
       }
       button {
-        font-size: 120%;
-        padding: 16px 30px;
-      }
-      @media screen and (max-width: 970px) {
-        .words-button {
-          font-size: 70%;
-          padding: 10px 20px;
-        }
-      }
-      @media screen and (max-width: 830px) {
-        .words-button {
-          font-size: 60%;
-        }
+        padding: 1.5% 3%;
       }
 
-      @media screen and (max-height: 1350px) {
-        #container {
-          max-width: 2050px;
-        }
+      @media screen {
+        #container { max-width: 770px; }
+        #container-react { font-size: calc(18px * 770 / 930); }
       }
-      @media screen and (max-height: 1260px) {
-        #container {
-          max-width: 1890px;
-        }
+      @media screen and (min-width: 1024px) and (min-height: 576px) {
+        #container { max-width: 930px; }
+        #container-react { font-size: calc(18px * 930 / 930); }
       }
-      @media screen and (max-height: 1170px) {
-        #container {
-          max-width: 1730px;
-        }
+      @media screen and (min-width: 1280px) and (min-height: 720px) {
+        #container { max-width: 1024px; }
+        #container-react { font-size: calc(18px * 1024 / 930); }
       }
-      @media screen and (max-height: 1080px) {
-        #container {
-          max-width: 1570px;
-        }
+      @media screen and (min-width: 1440px) and (min-height: 810px) {
+        #container { max-width: 1280px; }
+        #container-react { font-size: calc(18px * 1280 / 930); }
       }
-      @media screen and (max-height: 990px) {
-        #container {
-          max-width: 1410px;
-        }
-      }
-      @media screen and (max-height: 900px) {
-        #container {
-          max-width: 1250px;
-        }
-      }
-      @media screen and (max-height: 810px) {
-        #container {
-          max-width: 1090px;
-        }
-      }
-      @media screen and (max-height: 720px) {
-        #container {
-          max-width: 930px;
-        }
-      }
-      @media screen and (max-height: 630px) {
-        #container {
-          max-width: 770px;
-        }
-        .words-button {
-          font-size: 70%;
-          padding: 10px 20px;
-        }
-      input[type="radio"] {
-        cursor: pointer;
-      }
+
     </style>
   </head>
   <body>

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -71,21 +71,17 @@ const styles = {
   },
   finishButton: {
     backgroundColor: colors.orange,
-    color: colors.white
+    color: colors.white,
+    position: 'absolute',
+    bottom: '4%',
+    right: '2.25%',
   },
   playAgainButton: {
     backgroundColor: colors.yellowGreen,
     color: colors.white,
-    marginBottom: 10
-  },
-  rightButtons: {
     position: 'absolute',
-    bottom: 10,
-    right: 10,
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'right',
-    minWidth: '15%'
+    bottom: '16%',
+    right: '2.25%',
   },
   backButton: {
     position: 'absolute',
@@ -525,12 +521,12 @@ const styles = {
   },
   arrowLowerRight: {
     bottom: '17%',
-    right: '1%',
+    right: '2%',
     transform: 'translateX(-50%)'
   },
   arrowLowishRight: {
-    bottom: '25%',
-    right: '1%',
+    bottom: '28%',
+    right: '2%',
     transform: 'translateX(-50%)'
   },
   arrowLowerCenter: {
@@ -1262,7 +1258,7 @@ let Pond = class Pond extends React.Component {
         {state.canSkipPond && (
           <div>
             {state.appMode === AppMode.FishLong ? (
-              <div style={styles.rightButtons}>
+              <div>
                 <Button
                   style={styles.playAgainButton}
                   onClick={() => {

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -120,7 +120,7 @@ const styles = {
     top: '50%',
     bottom: 'initial',
     left: '50%',
-    padding: 20
+    padding: '2%'
   },
   confirmationDialogLeft: {
     float: 'left',
@@ -133,29 +133,33 @@ const styles = {
   confirmationHeader: {
     fontSize: '220%',
     color: colors.darkGrey,
-    padding: 10,
+    paddingBottom: '5%',
     textAlign: 'center'
   },
   confirmationText: {
     textAlign: 'center',
     backgroundColor: colors.lightGrey,
-    padding: '15px',
-    borderRadius: '5px'
+    padding: '5%',
+    borderRadius: 5
   },
   confirmationButtons: {
-    display: 'inline-flex',
-    justifyContent: 'space-between',
-    padding: '10px 0px',
-    width: '100%'
+    paddingTop: '5%',
+    clear: 'both'
   },
   confirmationYesButton: {
-    marginLeft: 10,
     backgroundColor: colors.red,
-    color: colors.white
+    color: colors.white,
+    left: '5%',
+    padding: '3.5% 8%',
+    width: '35%'
   },
   confirmationNoButton: {
     backgroundColor: colors.orange,
-    color: colors.white
+    color: colors.white,
+    float: 'right',
+    right: '5%',
+    padding: '3.5% 8%',
+    width: '35%'
   },
   activityIntroText: {
     position: 'absolute',
@@ -450,14 +454,14 @@ const styles = {
     position: 'relative'
   },
   guideImage: {
-    paddingTop: 20,
-    paddingLeft: 20,
-    maxWidth: '90%'
+    maxWidth: '90%',
+    padding: '20%',
+    boxSizing: 'border-box'
   },
   guideHeading: {
     fontSize: '220%',
     color: colors.darkGrey,
-    padding: 20
+    paddingBottom: '5%'
   },
   guideTypingText: {
     position: 'absolute',
@@ -500,7 +504,7 @@ const styles = {
     top: '50%',
     bottom: 'initial',
     left: '50%',
-    padding: 20
+    padding: '2%'
   },
   guideCenter: {
     top: '50%',
@@ -624,7 +628,9 @@ let ConfirmationDialog = class ConfirmationDialog extends React.Component {
     return (
       <div style={styles.confirmationDialogBackground}>
         <div style={styles.confirmationDialog}>
-          <img src={snail} style={styles.confirmationDialogLeft} />
+          <div style={styles.confirmationDialogLeft}>
+            <img src={snail} style={styles.guideImage}/>
+          </div>
           <div style={styles.confirmationDialogRight}>
             <div
               style={styles.confirmationHeader}

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -53,8 +53,9 @@ const styles = {
     cursor: 'pointer',
     backgroundColor: colors.white,
     color: colors.grey,
+    fontSize: '100%',
     borderRadius: 8,
-    minWidth: 160,
+    minWidth: '15%',
     outline: 'none',
     border: 'none',
     ':focus': {
@@ -84,7 +85,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     justifyContent: 'right',
-    minWidth: 160
+    minWidth: '15%'
   },
   backButton: {
     position: 'absolute',
@@ -134,8 +135,7 @@ const styles = {
     width: '70%'
   },
   confirmationHeader: {
-    fontSize: 40,
-    lineHeight: '40px',
+    fontSize: '220%',
     color: colors.darkGrey,
     padding: 10,
     textAlign: 'center'
@@ -163,8 +163,7 @@ const styles = {
   },
   activityIntroText: {
     position: 'absolute',
-    fontSize: 22,
-    lineHeight: '26px',
+    fontSize: '120%',
     top: '20%',
     left: '50%',
     width: '80%',
@@ -186,8 +185,7 @@ const styles = {
   wordsText: {
     textAlign: 'center',
     marginTop: 20,
-    fontSize: 22,
-    lineHeight: '26px',
+    fontSize: '120%',
     color: colors.white
   },
   eraseButton: {
@@ -201,8 +199,7 @@ const styles = {
     top: '15%',
     left: '50%',
     transform: 'translateX(-50%)',
-    fontSize: 32,
-    lineHeight: '35px',
+    fontSize: '180%',
     color: colors.white
   },
   trainButtons: {
@@ -252,7 +249,7 @@ const styles = {
     height: 25
   },
   counterNum: {
-    fontSize: 14,
+    fontSize: '80%',
     margin: '4px 7px'
   },
   mediaControls: {
@@ -265,7 +262,7 @@ const styles = {
   mediaControl: {
     cursor: 'pointer',
     margin: '0 20px',
-    fontSize: 30,
+    fontSize: '180%',
     color: colors.white,
     display: 'flex',
     alignItems: 'center',
@@ -281,7 +278,7 @@ const styles = {
   },
   timeScale: {
     width: 40,
-    fontSize: 24,
+    fontSize: '120%',
     textAlign: 'center'
   },
   predictSpeech: {
@@ -443,7 +440,6 @@ const styles = {
     position: 'absolute',
     backgroundColor: colors.transparentBlack,
     color: colors.white,
-    lineHeight: '140%',
     borderRadius: 5,
     maxWidth: '80%',
     bottom: '4%',
@@ -463,8 +459,7 @@ const styles = {
     maxWidth: '90%'
   },
   guideHeading: {
-    fontSize: 40,
-    lineHeight: '40px',
+    fontSize: '220%',
     color: colors.darkGrey,
     padding: 20
   },

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -494,7 +494,8 @@ const styles = {
     pointerEvents: 'none'
   },
   guideArrow: {
-    position: 'absolute'
+    position: 'absolute',
+    width: '8%'
   },
   guideInfo: {
     backgroundColor: colors.white,
@@ -514,19 +515,23 @@ const styles = {
   },
   arrowBotRight: {
     top: '15%',
-    right: '14.5%'
+    right: '8.9%',
+    transform: 'translateX(-50%)'
   },
   arrowLowerLeft: {
     bottom: '17%',
-    left: '6%'
+    left: '10%',
+    transform: 'translateX(-50%)'
   },
   arrowLowerRight: {
     bottom: '17%',
-    right: '6%'
+    right: '1%',
+    transform: 'translateX(-50%)'
   },
   arrowLowishRight: {
     bottom: '25%',
-    right: '5%'
+    right: '1%',
+    transform: 'translateX(-50%)'
   },
   arrowLowerCenter: {
     bottom: '25%',


### PR DESCRIPTION
This revisits responsive layout to keep the UI looking more consistent as the screen scales up and down.

Most notably, text now has a baseline size in px for the current screen size, and different pieces of text simply use percentage variants of that baseline.  Line height is a consistent multiplier, 1.3, of font size regardless of screen size.

Buttons now scale their padding relative to the width as well.

As for screen size, we just have four screen sizes to consider right now:

  - at least 1440x810
  - at least 1280x720
  - at least 1024x576
  - and anything smaller, in which case we show at least 770x433

It would be possible to add support for some larger screen sizes again, allowing the tutorial to fill even more of big screens.

Our baseline font size is an arbitrary 18px at 930px (which is what we show when the screen is at least 1024x576), and we scale up or down from that.

Also, the downward-facing guide arrow is now scaled, and is horizontally anchored to its center.
