### PR TITLE
Remove no-op sort call

### DIFF
--- a/src/demo/models/pond.js
+++ b/src/demo/models/pond.js
@@ -5,10 +5,9 @@ import constants, {ClassType, AppMode} from '../constants';
 
 export const init = async () => {
   const state = getState();
-  let fishWithConfidence = await predictAllFish(state);
-  fishWithConfidence = _.sortBy(fishWithConfidence, ['confidence']);
+  let fishWithPredictions = await predictAllFish(state);
   const fishByClassType = _.groupBy(
-    fishWithConfidence,
+    fishWithPredictions,
     fish => fish.getResult().predictedClassId
   );
 


### PR DESCRIPTION
The `sortBy` call doesn't do anything right now, since the `confidence` field is never defined on the fish object. (The fish object does have a confidence value, but it's in `.result.confidencesByClassId`.)

I personally think this behavior is better since it's better for allowing students to investigate misclassified fish. Discussed with Anthony as well - see slack thread in channel.

There's supposed to be no functional change in the code with this change, so if you see one, please let me know.