### PR TITLE
Fix instant ending

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -1335,7 +1335,7 @@ let Pond = class Pond extends React.Component {
                 </Button>
                 <Button
                   style={styles.finishButton}
-                  onClick={state.onContinue()}
+                  onClick={() => state.onContinue()}
                 >
                   Finish
                 </Button>


### PR DESCRIPTION
A recent regression saw us ending the final pond immediately when our host had provided a function for doing so.  An easy fix.