### PR TITLE
Start ids from wherever we last left off

### DIFF
--- a/src/demo/models/predict.js
+++ b/src/demo/models/predict.js
@@ -8,8 +8,8 @@ export const init = () => {
   state.trainer.train();
   let fishData = [];
   if (state.appMode === AppMode.CreaturesVTrashDemo) {
-    fishData = fishData.concat(generateOcean(4, true, true, false));
-    fishData = fishData.concat(generateOcean(3, false, false, true, 4));
+    fishData = fishData.concat(generateOcean(4, 0, true, true, false));
+    fishData = fishData.concat(generateOcean(3, 4, false, false, true));
   } else if (state.appMode === AppMode.FishLong) {
     fishData = generateOcean(200);
   } else {

--- a/src/demo/models/train.js
+++ b/src/demo/models/train.js
@@ -54,7 +54,7 @@ export const onClassifyFish = doesLike => {
 
   let fishData = [...state.fishData];
   if (state.trainingIndex > state.fishData.length - 5) {
-    fishData = fishData.concat(generateOcean(100));
+    fishData = fishData.concat(generateOcean(100, fishData.length));
   }
 
   if (doesLike) {

--- a/src/utils/generateOcean.js
+++ b/src/utils/generateOcean.js
@@ -17,10 +17,10 @@ import _ from 'lodash';
  */
 export const generateOcean = (
   numFish,
+  idStart = 0,
   loadFish = true,
   loadTrashImages,
-  loadCreatureImages,
-  idStart = 0
+  loadCreatureImages
 ) => {
   const state = getState();
   let ocean = [];


### PR DESCRIPTION
Theoretically we could have a situation where a fish's id is repeated within a small stretch of fish and could cause a cache collision as we were restarting the ids from 0 each time we generate some fish.

Example (generate 10 at a time with cache size of say 2):
generate some fish with ids [0, 3, 8, 2, 9, 1, 7, 5, 4, 6]
then generate some with ids [8, 6, 0, 1, 7, 5, 3, 2, 4, 9]
The last element of the first set will clash with the second element of the second set and will show the wrong fish due to the canvas cache.