### PR TITLE
Question text: don't wrap

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -208,7 +208,8 @@ const styles = {
     left: '50%',
     transform: 'translateX(-50%)',
     fontSize: '180%',
-    color: colors.white
+    color: colors.white,
+    whiteSpace: 'nowrap'
   },
   trainButtons: {
     position: 'absolute',


### PR DESCRIPTION
The training question text was wrapping on studio.code.org but not on our own repo.  I don't see an obvious reason in our styling why this would happen, but telling it not to wrap via CSS seems to fix it.