### PR TITLE
Pond: panel improvements

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -371,7 +371,8 @@ const styles = {
     borderRadius: 10,
     left: '3%',
     top: '16%',
-    padding: '2%'
+    padding: '2%',
+    pointerEvents: 'none'
   },
   pondPanelRight: {
     position: 'absolute',
@@ -381,7 +382,8 @@ const styles = {
     borderRadius: 10,
     right: '3%',
     top: '16%',
-    padding: '2%'
+    padding: '2%',
+    pointerEvents: 'none'
   },
   pondPanelPreText: {
     marginBottom: '5%'
@@ -1294,7 +1296,7 @@ let Pond = class Pond extends React.Component {
       });
 
       if (!fishClicked) {
-        setState({pondClickedFish: null, pondPanelShowing: false});
+        setState({pondClickedFish: null});
         playSound('no');
       }
     }
@@ -1308,8 +1310,7 @@ let Pond = class Pond extends React.Component {
       state.appMode === AppMode.FishLong
     ) {
       setState({
-        pondPanelShowing: !state.pondPanelShowing,
-        pondClickedFish: null
+        pondPanelShowing: !state.pondPanelShowing
       });
     }
 


### PR DESCRIPTION
After the latest round of bug bash feedback, some pond panel improvements.

Now, the button in the top-right is the only way to toggle panel mode on and off.  Once toggled on, if a fish was already selected, its panel shows right away.  Clicking on no fish just returns the default panel, until panel mode is turned off.

Another change is that the user can now click through the panel to a fish behind it.  This makes it easier to select fish even when the panel is over them.