### PR TITLE
Icon tweaks

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -252,17 +252,18 @@ const styles = {
   counter: {
     position: 'absolute',
     top: '2%',
-    right: '9%',
+    right: '7%',
     backgroundColor: colors.transparentBlack,
     color: colors.neonBlue,
     borderRadius: 33,
     textAlign: 'right',
-    minWidth: '9%',
-    height: '6%',
-    padding: '1% 3%'
+    minWidth: '7%',
+    height: '5%',
+    padding: '1% 2.5%'
   },
   counterImg: {
-    float: 'left'
+    float: 'left',
+    height: '100%'
   },
   counterNum: {
     fontSize: '90%'
@@ -274,7 +275,6 @@ const styles = {
     cursor: 'pointer',
     borderRadius: 50,
     padding: '0.75% 1.2%',
-    marginLeft: '2%',
     fontSize: '120%',
     backgroundColor: colors.white,
     color: colors.grey,

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -428,33 +428,35 @@ const styles = {
   pondPanelPostText: {
     marginTop: '3%'
   },
-  recallContainer: {
+  recallIcons: {
     position: 'absolute',
     top: '2%',
-    right: '1.2%',
-    color: colors.white,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between'
-  },
-  recallIcons: {
+    right: '7%',
     backgroundColor: colors.white,
     color: colors.grey,
-    maxHeight: 42,
+    height: '8.5%',
+    width: '9.5%',
     borderRadius: 8,
     display: 'flex',
     alignItems: 'center'
   },
   recallIcon: {
     cursor: 'pointer',
-    padding: 7
+    padding: '0 15%',
+    height: '100%'
   },
   infoIconContainer: {
+    position: 'absolute',
+    top: '2%',
+    right: '1.2%',
     cursor: 'pointer',
     borderRadius: 50,
-    marginLeft: 10,
+    padding: '0.75% 1.2%',
+    fontSize: '120%',
     backgroundColor: colors.white,
     color: colors.grey,
+    height: '6%',
+    width: '2.5%',
     ':hover': {
       backgroundColor: colors.neonBlue,
       color: colors.white
@@ -465,7 +467,9 @@ const styles = {
     }
   },
   infoIcon: {
-    padding: '5px 12px'
+    display: 'block',
+    margin: 'auto',
+    height: '100%'
   },
   bgNeonBlue: {
     backgroundColor: colors.neonBlue,
@@ -1345,42 +1349,40 @@ let Pond = class Pond extends React.Component {
     return (
       <Body>
         <div onClick={e => this.onPondClick(e)} style={styles.pondSurface} />
-        <div style={styles.recallContainer}>
-          <div style={styles.recallIcons}>
+        <div style={styles.recallIcons}>
+          <FontAwesomeIcon
+            icon={faCheck}
+            style={{
+              ...styles.recallIcon,
+              ...{borderTopLeftRadius: 8, borderBottomLeftRadius: 8},
+              ...(!state.showRecallFish ? styles.bgGreen : {})
+            }}
+            onClick={this.toggleRecall}
+          />
+          <FontAwesomeIcon
+            icon={faBan}
+            style={{
+              ...styles.recallIcon,
+              ...{borderTopRightRadius: 8, borderBottomRightRadius: 8},
+              ...(state.showRecallFish ? styles.bgRed : {})
+            }}
+            onClick={this.toggleRecall}
+          />
+        </div>
+        {showInfoButton && (
+          <div
+            style={{
+              ...styles.infoIconContainer,
+              ...(!state.pondPanelShowing ? {} : styles.bgNeonBlue)
+            }}
+          >
             <FontAwesomeIcon
-              icon={faCheck}
-              style={{
-                ...styles.recallIcon,
-                ...{borderTopLeftRadius: 8, borderBottomLeftRadius: 8},
-                ...(!state.showRecallFish ? styles.bgGreen : {})
-              }}
-              onClick={this.toggleRecall}
-            />
-            <FontAwesomeIcon
-              icon={faBan}
-              style={{
-                ...styles.recallIcon,
-                ...{borderTopRightRadius: 8, borderBottomRightRadius: 8},
-                ...(state.showRecallFish ? styles.bgRed : {})
-              }}
-              onClick={this.toggleRecall}
+              icon={faInfo}
+              style={styles.infoIcon}
+              onClick={this.onPondPanelButtonClick}
             />
           </div>
-          {showInfoButton && (
-            <div
-              style={{
-                ...styles.infoIconContainer,
-                ...(!state.pondPanelShowing ? {} : styles.bgNeonBlue)
-              }}
-            >
-              <FontAwesomeIcon
-                icon={faInfo}
-                style={styles.infoIcon}
-                onClick={this.onPondPanelButtonClick}
-              />
-            </div>
-          )}
-        </div>
+        )}
         <img style={styles.pondBot} src={aiBotClosed} />
         {state.canSkipPond && (
           <div>

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -249,35 +249,37 @@ const styles = {
     width: '49%',
     marginTop: '30%'
   },
-  trainingIcons: {
+  counter: {
     position: 'absolute',
     top: '2%',
-    right: '1.2%',
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center'
-  },
-  counter: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+    right: '9%',
     backgroundColor: colors.transparentBlack,
     color: colors.neonBlue,
     borderRadius: 33,
-    padding: '9px 20px',
-    minWidth: 65
+    textAlign: 'right',
+    minWidth: '9%',
+    height: '6%',
+    padding: '1% 3%'
+  },
+  counterImg: {
+    float: 'left'
   },
   counterNum: {
-    fontSize: '90%',
-    marginLeft: 12
+    fontSize: '90%'
   },
   eraseButtonContainer: {
+    position: 'absolute',
+    top: '2%',
+    right: '1.2%',
     cursor: 'pointer',
     borderRadius: 50,
-    padding: 8,
-    marginLeft: 10,
+    padding: '0.75% 1.2%',
+    marginLeft: '2%',
+    fontSize: '120%',
     backgroundColor: colors.white,
     color: colors.grey,
+    height: '6%',
+    width: '2.4%',
     ':hover': {
       backgroundColor: colors.red,
       color: colors.white
@@ -288,7 +290,9 @@ const styles = {
     }
   },
   eraseButton: {
-    padding: '0 3px'
+    display: 'block',
+    margin: 'auto',
+    height: '100%'
   },
   mediaControls: {
     position: 'absolute',
@@ -736,7 +740,10 @@ ConfirmationDialog = Radium(ConfirmationDialog);
 const wordSet = {
   short: {
     text: ['What type of fish do you want to train A.I. to detect?'],
-    choices: [['Blue', 'Green', 'Red'], ['Circular', 'Rectangular', 'Triangular']],
+    choices: [
+      ['Blue', 'Green', 'Red'],
+      ['Circular', 'Rectangular', 'Triangular']
+    ],
     style: styles.button2col
   },
   long: {
@@ -861,25 +868,23 @@ let Train = class Train extends React.Component {
           />
           <img src={aiBotBody} style={styles.trainBotBody} />
         </div>
-        <div style={styles.trainingIcons}>
-          <div style={styles.counter}>
-            <img src={counterIcon} />
-            <span style={styles.counterNum}>
-              {Math.min(999, state.yesCount + state.noCount)}
-            </span>
-          </div>
-          <span style={styles.eraseButtonContainer}>
-            <FontAwesomeIcon
-              icon={faTrash}
-              style={styles.eraseButton}
-              onClick={() => {
-                setState({
-                  showConfirmationDialog: true,
-                  confirmationDialogOnYes: resetTrainingFunction
-                });
-              }}
-            />
+        <div style={styles.counter}>
+          <img src={counterIcon} style={styles.counterImg} />
+          <span style={styles.counterNum}>
+            {Math.min(999, state.yesCount + state.noCount)}
           </span>
+        </div>
+        <div style={styles.eraseButtonContainer}>
+          <FontAwesomeIcon
+            icon={faTrash}
+            style={styles.eraseButton}
+            onClick={() => {
+              setState({
+                showConfirmationDialog: true,
+                confirmationDialogOnYes: resetTrainingFunction
+              });
+            }}
+          />
         </div>
         <div style={styles.trainButtons}>
           <Button
@@ -1458,7 +1463,7 @@ let Guide = class Guide extends React.Component {
     if (!state.guideShowing && !state.guideTypingTimer && currentGuide) {
       const guideTypingTimer = setInterval(() => {
         playSound('no', 0.5);
-      }, 1000/10);
+      }, 1000 / 10);
       setState({guideTypingTimer});
     }
 


### PR DESCRIPTION
Refactored the circular icons because they weren't circular on mobile devices. Bug report from Mark in Slack [here](https://codedotorg.slack.com/archives/CMV01LWPL/p1574901038038900).

**Note:** The diff for this looks pretty large because I ended up deleting two `<div>` wrappers for the icons as they ended up being unnecessary. Please don't let the diff scare you 🙂 

**Training screen icons:**

desktop--
<img width="1037" alt="Screen Shot 2019-11-27 at 6 00 00 PM" src="https://user-images.githubusercontent.com/9812299/69770934-c1c8de00-113f-11ea-8a53-9d7108da3101.png">

mobile--
<img width="487" alt="Screen Shot 2019-11-27 at 5 59 50 PM" src="https://user-images.githubusercontent.com/9812299/69770935-c1c8de00-113f-11ea-95de-e1d768421c3e.png">

**Results screen icons:**

desktop--
<img width="1052" alt="Screen Shot 2019-11-27 at 5 59 18 PM" src="https://user-images.githubusercontent.com/9812299/69770938-c1c8de00-113f-11ea-80ca-d3207a5bc09d.png">

mobile--
<img width="488" alt="Screen Shot 2019-11-27 at 5 59 29 PM" src="https://user-images.githubusercontent.com/9812299/69770937-c1c8de00-113f-11ea-99dc-e22a2fddfd32.png">
