### PR TITLE
Buttons: fix line-height

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -60,7 +60,8 @@ const styles = {
     minWidth: '15%',
     outline: 'none',
     border: 'none',
-    whiteSpace: 'nowrap'
+    whiteSpace: 'nowrap',
+    lineHeight: 1.3
   },
   continueButton: {
     position: 'absolute',


### PR DESCRIPTION
On both the standalone and embedded versions of the tutorial, the normal line-height of 1.3 was being overwritten by button CSS.  This fixes it, and now all the buttons scale down to the smallest mobile size more properly.