### PR TITLE
Fix the info button click

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -1384,11 +1384,11 @@ let Pond = class Pond extends React.Component {
               ...styles.infoIconContainer,
               ...(!state.pondPanelShowing ? {} : styles.bgNeonBlue)
             }}
+            onClick={this.onPondPanelButtonClick}
           >
             <FontAwesomeIcon
               icon={faInfo}
               style={styles.infoIcon}
-              onClick={this.onPondPanelButtonClick}
             />
           </div>
         )}


### PR DESCRIPTION
The whole button can be clicked now, not just its "i" icon.