### PR TITLE
Buttons: center content of buttons with icons

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -610,9 +610,6 @@ const styles = {
     top: '15%',
     right: '-4.6%',
     transform: 'translateX(-50%) rotate(180deg)'
-  },
-  marginRight: {
-    marginRight: '12%'
   }
 };
 
@@ -900,7 +897,9 @@ let Train = class Train extends React.Component {
             }}
             sound={'no'}
           >
-            <FontAwesomeIcon icon={faBan} style={styles.marginRight} />
+            <FontAwesomeIcon icon={faBan} />
+            &nbsp;
+            &nbsp;
             {noButtonText}
           </Button>
           <Button
@@ -911,7 +910,9 @@ let Train = class Train extends React.Component {
             }}
             sound={'yes'}
           >
-            <FontAwesomeIcon icon={faCheck} style={styles.marginRight} />
+            <FontAwesomeIcon icon={faCheck} />
+            &nbsp;
+            &nbsp;
             {yesButtonText}
           </Button>
         </div>
@@ -1058,7 +1059,9 @@ let Predict = class Predict extends React.Component {
         )}
         {!state.isRunning && !state.isPaused && (
           <Button style={styles.continueButton} onClick={this.onRun}>
-            <FontAwesomeIcon icon={faPlay} style={styles.marginRight} />
+            <FontAwesomeIcon icon={faPlay} />
+            &nbsp;
+            &nbsp;
             Run
           </Button>
         )}
@@ -1389,10 +1392,7 @@ let Pond = class Pond extends React.Component {
             }}
             onClick={this.onPondPanelButtonClick}
           >
-            <FontAwesomeIcon
-              icon={faInfo}
-              style={styles.infoIcon}
-            />
+            <FontAwesomeIcon icon={faInfo} style={styles.infoIcon} />
           </div>
         )}
         <img style={styles.pondBot} src={aiBotClosed} />


### PR DESCRIPTION
For some reason, the margin to the right of the icon was causing the text to be pushed to the right of center in such buttons.

This uses non-breaking spaces to achieve a similar effect, but now the content is properly centered.

### before
![Screenshot 2019-11-28 01 18 36](https://user-images.githubusercontent.com/2205926/69793972-44708e00-117e-11ea-9c46-d66c41ca3a6e.png)

### after
![Screenshot 2019-11-28 01 30 09](https://user-images.githubusercontent.com/2205926/69794173-a4673480-117e-11ea-9f80-8b5ad3d89a16.png)

