### PR TITLE
Analytics: page views & word events

### DIFF
--- a/src/demo/models/index.js
+++ b/src/demo/models/index.js
@@ -25,4 +25,20 @@ export const init = state => {
       initPond();
       break;
   }
+
+  // Report a synthetic pageview to Google Analytics.
+  if (window.ga) {
+    const modeToPage = {
+      [Modes.Loading]: "loading",
+      [Modes.Words]: "words",
+      [Modes.Training]: "training",
+      [Modes.Predicting]: "predicting",
+      [Modes.Pond]: "pond",
+      [Modes.Instructions]:"instructions"
+    };
+
+    const syntheticPagePath = window.location.pathname + '/' + modeToPage[state.currentMode];
+    window.ga('set', 'page', syntheticPagePath);
+    window.ga('send', 'pageview');
+  }
 };

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -817,7 +817,7 @@ let Words = class Words extends React.Component {
         [AppMode.FishLong]: 'words-long'
       };
 
-      trackEvent(
+      window.trackEvent(
         'oceans',
         appModeToString[getState().appMode],
         word.toLowerCase()

--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -809,6 +809,20 @@ let Words = class Words extends React.Component {
       trainingQuestion: `Is this fish “${word.toLowerCase()}”?`
     });
     toMode(Modes.Training);
+
+    // Report an analytics event for the word chosen.
+    if (window.trackEvent) {
+      const appModeToString = {
+        [AppMode.FishShort]: 'words-short',
+        [AppMode.FishLong]: 'words-long'
+      };
+
+      trackEvent(
+        'oceans',
+        appModeToString[getState().appMode],
+        word.toLowerCase()
+      );
+    }
   }
 
   render() {
@@ -898,8 +912,7 @@ let Train = class Train extends React.Component {
             sound={'no'}
           >
             <FontAwesomeIcon icon={faBan} />
-            &nbsp;
-            &nbsp;
+            &nbsp; &nbsp;
             {noButtonText}
           </Button>
           <Button
@@ -911,8 +924,7 @@ let Train = class Train extends React.Component {
             sound={'yes'}
           >
             <FontAwesomeIcon icon={faCheck} />
-            &nbsp;
-            &nbsp;
+            &nbsp; &nbsp;
             {yesButtonText}
           </Button>
         </div>
@@ -1060,9 +1072,7 @@ let Predict = class Predict extends React.Component {
         {!state.isRunning && !state.isPaused && (
           <Button style={styles.continueButton} onClick={this.onRun}>
             <FontAwesomeIcon icon={faPlay} />
-            &nbsp;
-            &nbsp;
-            Run
+            &nbsp; &nbsp; Run
           </Button>
         )}
         {(state.isRunning || state.isPaused) && state.canSkipPredict && (


### PR DESCRIPTION
This adds some extra analytics tracking for when the app is running inside of `studio.code.org`.

- A synthetic page view is generated as each mode is entered.  This will show up like `/s/oceans/stage/1/puzzle/8/loading` and `/s/oceans/stage/1/puzzle/8/pond`.
- An event is generated for each word selected.  This will show up like `oceans, words-short, triangular` and `oceans, words-long, awesome`.