### PR TITLE
improve prompts to encourage more training

### DIFF
--- a/src/demo/models/guide.js
+++ b/src/demo/models/guide.js
@@ -303,12 +303,12 @@ const guides = [
   },
   {
     id: 'fishshort-words-training-pause1',
-    text: `Nice work.  Keep training.`,
+    text: `Do you think A.I. has enough training data?  You could click Continue to find out.`,
     when: {
       appMode: AppMode.FishShort,
       currentMode: Modes.Training,
       fn: state => {
-        return state.yesCount + state.noCount >= 15;
+        return state.yesCount + state.noCount >= 5;
       }
     }
   },
@@ -404,7 +404,7 @@ const guides = [
   },
   {
     id: 'fishlong-training-pause4',
-    text: `Great work!  Keep training A.I. or continue when ready.`,
+    text: `Do you think A.I. has enough training data?  A.I. will do better with a lot of data.  Continue when you think A.I. is ready.`,
     when: {
       appMode: AppMode.FishLong,
       currentMode: Modes.Training,
@@ -455,7 +455,13 @@ const guides = [
   },
   {
     id: 'fishlong-pond-init2',
-    text: 'Try out a new word by clicking the New Word button.',
+    text: `You can choose to Train More if you want to improve the results.`,
+    when: {appMode: AppMode.FishLong, currentMode: Modes.Pond},
+    arrow: 'LowerLeft'
+  },
+  {
+    id: 'fishlong-pond-init3',
+    text: `Or you can teach A.I. a new word by choosing New Word.`,
     when: {appMode: AppMode.FishLong, currentMode: Modes.Pond},
     arrow: 'LowishRight'
   }

--- a/src/demo/models/guide.js
+++ b/src/demo/models/guide.js
@@ -308,7 +308,7 @@ const guides = [
       appMode: AppMode.FishShort,
       currentMode: Modes.Training,
       fn: state => {
-        return state.yesCount + state.noCount >= 5;
+        return state.yesCount + state.noCount >= 10;
       }
     }
   },

--- a/src/demo/models/guide.js
+++ b/src/demo/models/guide.js
@@ -303,7 +303,7 @@ const guides = [
   },
   {
     id: 'fishshort-words-training-pause1',
-    text: `Do you think A.I. has enough training data?  You could click Continue to find out.`,
+    text: `Do you think A.I. has enough training data?  You can click Continue to find out.`,
     when: {
       appMode: AppMode.FishShort,
       currentMode: Modes.Training,


### PR DESCRIPTION
changes to a few prompts to emphasize connection between amount of training data and results.

1. change to part 2a to encourage the student to try continuing after only 5 training attempts to see the result. from the screen shots you can see the new guide prompt, and the results screen with lots of non circular fish after only training 5 times. we then encourage them to train more for a better result.
![image](https://user-images.githubusercontent.com/8651388/69922414-edeea280-1450-11ea-9379-11ae350df284.png)
![image](https://user-images.githubusercontent.com/8651388/69922420-05c62680-1451-11ea-92e7-326424c2a215.png)
2. change to text around training more than 100 in part 2b and breaking prompts for train more or new word on the final screen to help students consider training more if they are not happy with the results screen.
![image](https://user-images.githubusercontent.com/8651388/69922483-79683380-1451-11ea-8570-3d5867326aa8.png)
![image](https://user-images.githubusercontent.com/8651388/69922487-838a3200-1451-11ea-9839-83f280ce2462.png)
