### PR TITLE
Increase the speed at which the rejected items 'fall'

### DIFF
--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -290,7 +290,7 @@ const getYForFish = (numFish, fishIdx, state, offsetX, predictedClassId) => {
         constants.canvasWidth / 2 - constants.fishCanvasWidth / 2;
       const screenX = getXForFish(numFish, fishIdx, offsetX);
       if (screenX > midScreenX) {
-        y += screenX - midScreenX;
+        y += 1.2 * (screenX - midScreenX);
       }
     }
 


### PR DESCRIPTION
The fact that the fall speed is a bit faster than the horizontal movement is noticeable but I think it's okay. Definitely open to feedback and could restrict this to the creaturesvtrashdemo mode.