### PR TITLE
Fix travis timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 dist: xenial
 
 node_js:
-- 8.12.0
+  - 8.12.0
 
 cache:
   yarn: true
@@ -12,6 +12,9 @@ cache:
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install build-essential g++
+
+install:
+  - travis_wait mvn install
 
 script:
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install build-essential g++
 
-install:
-  - travis_wait yarn test
-
 script:
-  - yarn test
+  - travis_wait yarn test
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - sudo apt-get install build-essential g++
 
 install:
-  - travis_wait mvn install
+  - travis_wait yarn test
 
 script:
   - yarn test


### PR DESCRIPTION
Our unit tests now usually take longer than 10 min and do not print to stdout during that time, which causes Travis to timeout by default. Increasing the timeout on `yarn test` from 10 to 20 minutes.

[Travis documentation](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received)
[Slack thread](https://codedotorg.slack.com/archives/CMV01LWPL/p1575324285022900)