### PR TITLE
Fix pond panel problem on new word

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -1431,6 +1431,7 @@ let Pond = class Pond extends React.Component {
                 <Button
                   style={styles.playAgainButton}
                   onClick={() => {
+                    setState({pondClickedFish: null, pondPanelShowing: false});
                     resetTraining(state);
                     toMode(Modes.Words);
                   }}


### PR DESCRIPTION
If the pond panel was open and we chose New Word, the next time we came back to the pond there was a pond panel showing bad information.

Now, we clear state properly when going back to choose a new word.

## Pond panel problem

![Screenshot 2019-12-03 09 03 13](https://user-images.githubusercontent.com/2205926/70072903-c0b70700-15ac-11ea-89a2-a483dae06736.png)

## Aside

I think this cements my inkling that state should be set comprehensively somewhere outside of UI code.  Especially in case we want to transition to the same state from multiple pieces of UI.