### PR TITLE
Add maxWidth to info modal typing text

### DIFF
--- a/src/demo/ui.jsx
+++ b/src/demo/ui.jsx
@@ -1536,7 +1536,12 @@ let Guide = class Guide extends React.Component {
                       {currentGuide.heading}
                     </div>
                   )}
-                  <div style={styles.guideTypingText}>
+                  <div
+                    style={[
+                      styles.guideTypingText,
+                      currentGuide.style === 'Info' && {maxWidth: '85%'}
+                    ]}
+                  >
                     <Typist
                       avgTypingDelay={35}
                       stdTypingDelay={15}


### PR DESCRIPTION
@breville noticed a width issue on the info modals' typing text:
<img width="612" alt="Screen Shot 2019-12-03 at 1 12 46 AM" src="https://user-images.githubusercontent.com/9812299/70077662-2065e000-15b6-11ea-8566-c50cc0e7c199.png">

Fixed by setting a maxWidth on the typing text for "Info" guides only:
![Screen Shot 2019-12-03 at 10 16 34 AM](https://user-images.githubusercontent.com/9812299/70077668-2491fd80-15b6-11ea-9902-42c311afc329.png)
