### PR TITLE
Add @ml alias to /src/ dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "jest": {
     "testEnvironment": "node",
     "moduleNameMapper": {
-      ".+\\.(bin|jpg|jpeg|png|mp3|ogg|wav)$": "identity-obj-proxy"
+      ".+\\.(bin|jpg|jpeg|png|mp3|ogg|wav)$": "identity-obj-proxy",
+      "^@ml(.*)$": "<rootDir>/src/$1"
     }
   },
   "scripts": {

--- a/test/unit/demo/helpers.test.js
+++ b/test/unit/demo/helpers.test.js
@@ -1,5 +1,5 @@
-import {filterFishComponents} from '../../../src/demo/helpers';
-import {AppMode} from '../../../src/demo/constants';
+import {filterFishComponents} from '@ml/demo/helpers';
+import {AppMode} from '@ml/demo/constants';
 
 describe('filterFishComponents', () => {
   const fishComponents = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,96 +1,109 @@
-const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+const {CleanWebpackPlugin} = require('clean-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
+const path = require('path');
 
 const commonConfig = {
   devtool: 'eval-cheap-module-source-map',
   resolve: {
     extensions: ['.js', '.jsx'],
+    alias: {
+      '@ml': path.resolve(__dirname, 'src')
+    }
   },
   output: {
     filename: '[name].js',
-    libraryTarget: 'umd',
+    libraryTarget: 'umd'
   },
   module: {
-    rules: [{
-      test: /\.js$/,
-      loader: "babel-loader",
-    },
-    {test: /\.css$/, loader: 'style-loader!css-loader'},
-    {
-      test: /\.jsx$/,
-      enforce: 'pre',
-      exclude: /(node_modules)/,
-      use: [{
-        loader: 'babel-loader',
+    rules: [
+      {
+        test: /\.js$/,
+        loader: 'babel-loader'
+      },
+      {test: /\.css$/, loader: 'style-loader!css-loader'},
+      {
+        test: /\.jsx$/,
+        enforce: 'pre',
+        exclude: /(node_modules)/,
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['react', 'env'],
+              plugins: ['transform-class-properties']
+            }
+          }
+        ]
+      },
+      {
+        test: /\.(png|gif)$/,
+        loader: 'url-loader',
         options: {
-          presets: ['react', 'env'],
-          plugins: ["transform-class-properties"]
+          limit: 8192,
+          outputPath: 'assets/images',
+          publicPath: 'images',
+          postTransformPublicPath: p =>
+            `__ml_activities_asset_public_path__ + ${p}`,
+          name: '[name].[ext]?[contenthash]'
         }
-      }]
-    },
-    {
-      test: /\.(png|gif)$/,
-      loader: "url-loader",
-      options: {
-        limit: 8192,
-        outputPath: 'assets/images',
-        publicPath: 'images',
-        postTransformPublicPath: (p) => `__ml_activities_asset_public_path__ + ${p}`,
-        name: '[name].[ext]?[contenthash]',
-      }
-    },
-    {
-      type: 'javascript/auto',
-      test: /src\/demo\/model.json$/,
-      use: [
+      },
+      {
+        type: 'javascript/auto',
+        test: /src\/demo\/model.json$/,
+        use: [
           {
             loader: 'file-loader',
             options: {
               outputPath: 'assets/models',
               publicPath: 'models',
-              postTransformPublicPath: (p) => `__ml_activities_asset_public_path__ + ${p}`,
-              name: '[name].[ext]?[contenthash]',
+              postTransformPublicPath: p =>
+                `__ml_activities_asset_public_path__ + ${p}`,
+              name: '[name].[ext]?[contenthash]'
             }
           }
-      ]
-    },
-    {
-      test: /\.(mp3|ogg|wav)$/,
-      loader: "file-loader",
-      options: {
-        outputPath: 'assets/sounds',
-        publicPath: 'sounds',
-        postTransformPublicPath: (p) => `__ml_activities_asset_public_path__ + ${p}`,
-        name: '[name].[ext]?[contenthash]',
+        ]
+      },
+      {
+        test: /\.(mp3|ogg|wav)$/,
+        loader: 'file-loader',
+        options: {
+          outputPath: 'assets/sounds',
+          publicPath: 'sounds',
+          postTransformPublicPath: p =>
+            `__ml_activities_asset_public_path__ + ${p}`,
+          name: '[name].[ext]?[contenthash]'
+        }
       }
-    }],
+    ]
   },
   performance: {
-    assetFilter: function (assetFilename) {
-      return (/^assets\//.test(assetFilename));
+    assetFilter: function(assetFilename) {
+      return /^assets\//.test(assetFilename);
     },
     maxAssetSize: 300000,
-    maxEntrypointSize: 10500000,
+    maxEntrypointSize: 10500000
   }
 };
 
 const firstConfigOnly = {
   plugins: [
     new CleanWebpackPlugin(),
-    new CopyPlugin([{
-      from: 'src/demo/*.bin',
-      to: 'assets/models/',
-      flatten: true,
-    }]),
-  ],
+    new CopyPlugin([
+      {
+        from: 'src/demo/*.bin',
+        to: 'assets/models/',
+        flatten: true
+      }
+    ])
+  ]
 };
 
 const externalConfig = {
   externals: {
-    "lodash": "lodash",
-    "radium": "radium",
-    "react": "react",
-    "react-dom": "react-dom",
+    lodash: 'lodash',
+    radium: 'radium',
+    react: 'react',
+    'react-dom': 'react-dom'
   }
 };
 
@@ -123,10 +136,7 @@ const productionConfig = [
 
 module.exports = (env, argv) => {
   if (argv.mode === 'production') {
-    return [
-      ...defaultConfig,
-      ...productionConfig,
-    ];
+    return [...defaultConfig, ...productionConfig];
   }
 
   return defaultConfig;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,6 +6,8 @@ const commonConfig = {
   devtool: 'eval-cheap-module-source-map',
   resolve: {
     extensions: ['.js', '.jsx'],
+    // Note: Separate aliases are required for aliases to work in unit tests. These should
+    // be added in package.json in the jest configuration.
     alias: {
       '@ml': path.resolve(__dirname, 'src')
     }


### PR DESCRIPTION
Now we can reference the `ml-activities/src/` dir as just `@ml/` to make our imports a little cleaner. I updated the `helpers.test.js` file in this PR to show an example, but didn't want to update every import in this PR.