### PR TITLE
Don't render UI on every frame

### DIFF
--- a/src/demo/renderer.js
+++ b/src/demo/renderer.js
@@ -135,27 +135,39 @@ export const render = () => {
 
       if (state.appMode === AppMode.CreaturesVTrashDemo) {
         if (state.biasTextTime) {
-          setState({
-            canSkipPredict:
-              $time() >= state.biasTextTime + timeBeforeCanSkipBiasText
-          });
+          if (
+            !state.canSkipPredict &&
+            $time() >= state.biasTextTime + timeBeforeCanSkipBiasText
+          ) {
+            setState({
+              canSkipPredict: true
+            });
+          }
         }
       } else if (state.isRunning) {
-        setState({
-          canSkipPredict:
-            $time() >= state.runStartTime + timeBeforeCanSkipPredict
-        });
+        if (
+          !state.canSkipPredict &&
+          $time() >= state.runStartTime + timeBeforeCanSkipPredict
+        ) {
+          setState({
+            canSkipPredict: true
+          });
+        }
       }
 
       break;
     case Modes.Pond:
       drawPondFishImages();
 
-      setState({
-        canSkipPond: $time() >= currentModeStartTime + timeBeforeCanSkipPond,
-        canSeePondText:
-          $time() >= currentModeStartTime + timeBeforeCanSeePondText
-      });
+      if (
+        !state.canSkipPond &&
+        $time() >= currentModeStartTime + timeBeforeCanSkipPond
+      ) {
+        setState({canSkipPond: true});
+      }
+      if (!state.canSeePondText) {
+        setState({canSeePondText: true});
+      }
       break;
   }
 
@@ -577,7 +589,7 @@ const drawWordFishImages = () => {
     }
   });
 
-  setState({fishCount});
+  setState({fishCount}, {skipCallback: true});
 };
 
 const pondFishTransitionTime = 1500;


### PR DESCRIPTION
While it appears to be a no-op in React and hopefully hasn't been harmful to our performance, we wanted to avoid telling React to update its UI every frame.  There were a few cases where we were still doing that, but didn't need to be.