### PR TITLE
Remove globals object now that we are using jsdom testEnvironment

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,7 @@
       "^@ml(.*)$": "<rootDir>/src/$1",
       "^@public(.*)$": "<rootDir>/public/$1"
     },
-    "setupTestFrameworkScriptFile": "<rootDir>/test/setup.js",
-    "globals": {
-      "window": {},
-      "location": {}
-    }
+    "setupTestFrameworkScriptFile": "<rootDir>/test/setup.js"
   },
   "scripts": {
     "build": "webpack -p",


### PR DESCRIPTION
I added this a while back because our jest testEnvironment was node (rather than the default jsdom) and our React unit tests require the window+document globals. Now that our default environment is jsdom, we no longer need these globals!