### PR TITLE
Start of RTL support

### DIFF
--- a/src/oceans/ui.jsx
+++ b/src/oceans/ui.jsx
@@ -236,22 +236,26 @@ const styles = {
     position: 'absolute',
     top: '30%',
     right: '-2%',
-    width: '30%'
+    width: '30%',
+    direction: 'ltr'
   },
   trainBotHead: {
     transition: 'transform 500ms',
     left: '3%',
     width: '43%',
     top: '0%',
-    position: 'absolute'
+    position: 'absolute',
+    direction: 'ltr'
   },
   trainBotOpen: {
     transform: 'rotate(90deg)',
-    transformOrigin: 'bottom right'
+    transformOrigin: 'bottom right',
+    direction: 'ltr'
   },
   trainBotBody: {
     width: '49%',
-    marginTop: '30%'
+    marginTop: '30%',
+    direction: 'ltr'
   },
   counter: {
     position: 'absolute',
@@ -303,7 +307,8 @@ const styles = {
     width: '100%',
     bottom: '3.5%',
     display: 'flex',
-    justifyContent: 'center'
+    justifyContent: 'center',
+    direction: 'ltr'
   },
   mediaControl: {
     cursor: 'pointer',
@@ -442,7 +447,8 @@ const styles = {
     width: '9.5%',
     borderRadius: 8,
     display: 'flex',
-    alignItems: 'center'
+    alignItems: 'center',
+    direction: 'ltr'
   },
   recallIcon: {
     cursor: 'pointer',


### PR DESCRIPTION
This just sets the direction of the bot (and its head) to be `ltr` all the time as well as the recall buttons.

There's still some weirdness with button padding in RTL on the local build but I couldn't repro them on code-dot-org. The buttons are flipped in RTL, which is probably okay, but I'm open to feedback. 

Code studio screenshot (with a couple translations I pulled off Crowdin):
![Screenshot 2019-12-20 at 2 07 06 PM](https://user-images.githubusercontent.com/46464143/71295913-baf24d00-2332-11ea-95db-d6e5fe06e727.png)
