### PR TITLE
Enable react/no-danger linter rule 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,6 +65,7 @@ module.exports = {
     "react/jsx-key": "off",
     "react/jsx-no-target-blank": "off",
     "react/jsx-wrap-multilines": "error", // autofixable
+    "react/no-danger": "error",
     "react/no-find-dom-node": "off",
     "react/no-render-return-value": "off",
     "react/no-string-refs": "off",


### PR DESCRIPTION
This rule is good practice anyway but with translated strings we should definitely never use `dangerouslySetInnerHtml`.