### PR TITLE
STAR-1608: Fix missing dependency. Use @code-dot-org fork of svm

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "remark-rehype": "^5.0.0",
     "sinon": "^7.5.0",
     "style-loader": "^1.0.0",
-    "svm": "uponthesun/svmjs",
+    "@code-dot-org/svm": "^0.1.1",
     "url-loader": "^2.2.0",
     "webpack": "4.19.1",
     "webpack-bundle-analyzer": "^3.6.0",

--- a/src/utils/SVMTrainer.js
+++ b/src/utils/SVMTrainer.js
@@ -1,4 +1,4 @@
-const svmjs = require('svm'); // https://github.com/karpathy/svmjs
+const svmjs = require('@code-dot-org/svm');
 import {ClassType} from '../oceans/constants'
 
 const SVM_PARAMS = {maxiter: 500}; // See https://github.com/karpathy/svmjs/blob/b75b71289dd81fc909a5b3fb8b1caf20fbe45121/lib/svm.js#L27

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,11 @@
     remark-stringify "^6.0.0"
     unified "^7.0.0"
 
+"@code-dot-org/svm@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/svm/-/svm-0.1.1.tgz#c3575bdee2ae536c64c54c9cb9deffa92c6beb6a"
+  integrity sha512-j9wMvatjeo6HDI9Q2oDBIIaZj9mIMZkQXl04h5I6yuXyCEJrkULn2Yophxv/6f2DtSVZRxYpoQJkFGlXB37Gww==
+
 "@fortawesome/fontawesome-common-types@^0.2.25":
   version "0.2.25"
   resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.25.tgz#6df015905081f2762e5cfddeb7a20d2e9b16c786"
@@ -8325,10 +8330,6 @@ supports-color@^5.3.0, supports-color@^5.5.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
-
-svm@uponthesun/svmjs:
-  version "0.1.0"
-  resolved "https://codeload.github.com/uponthesun/svmjs/tar.gz/c58634881d214c854cd2a5bef1b4efd14a8997f8"
 
 symbol-tree@^3.2.2:
   version "3.2.4"


### PR DESCRIPTION
One of our forked dependencies was deleted which was causing our builds to break. I recreated the dependency in https://github.com/code-dot-org/svmjs/pull/1 and have updated the references here.

[STAR-1608](https://codedotorg.atlassian.net/browse/STAR-1608)