### PR TITLE
Potential updates to guide reminder

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "jsx"
     ],
     "moduleNameMapper": {
-      ".+\\.(bin|jpg|jpeg|png|mp3|ogg|wav|gif)$": "identity-obj-proxy",
+      ".+\\.(bin|jpg|jpeg|png|mp3|ogg|wav|gif|svg|css)$": "identity-obj-proxy",
       "^@ml(.*)$": "<rootDir>/src/$1",
       "^@public(.*)$": "<rootDir>/public/$1"
     },

--- a/public/index.html
+++ b/public/index.html
@@ -48,7 +48,7 @@
       button {
         padding: 1.5% 3%;
       }
-      
+
       #pondTextMarkdown p {
         margin: 0
       }
@@ -104,6 +104,14 @@
         }
         #container-react {
           font-size: calc(18px * 1024 / 930);
+        }
+      }
+      @media screen and (min-width: 1422px) and (min-height: 830px) {
+        #container {
+          max-width: 1280px;
+        }
+        #container-react {
+          font-size: calc(18px * 1280 / 930);
         }
       }
     </style>

--- a/src/oceans/components/common/Guide.jsx
+++ b/src/oceans/components/common/Guide.jsx
@@ -55,8 +55,8 @@ let UnwrappedGuide = class Guide extends React.Component {
     const renderClickToContinueReminder =
       state.guides === 'K5' &&
       state.guideShowing &&
-      !guide.getCurrentGuide().noDimBackground &&
-      guide.getCurrentGuide().style !== 'Info';
+      !currentGuide.noDimBackground &&
+      currentGuide.style !== 'Info';
 
     return (
       <div>
@@ -109,10 +109,7 @@ let UnwrappedGuide = class Guide extends React.Component {
                     </div>
                   </div>
                   {renderClickToContinueReminder && (
-                    <div
-                      id="click-to-continue-reminder"
-                      style={styles.guideClickToContinueReminderContainer}
-                    >
+                    <div style={styles.guideClickToContinueReminderContainer}>
                       <img
                         src={fingerClickIcon1}
                         alt=""

--- a/src/oceans/components/common/Guide.jsx
+++ b/src/oceans/components/common/Guide.jsx
@@ -17,9 +17,7 @@ import fingerClickIcon2 from '@public/images/finger-click-icon-2.svg';
 
 let UnwrappedGuide = class Guide extends React.Component {
   onShowing() {
-    const state = getState();
-
-    clearInterval(state.guideTypingTimer);
+    clearInterval(getState().guideTypingTimer);
     setState({guideShowing: true, guideTypingTimer: null});
   }
 
@@ -28,7 +26,7 @@ let UnwrappedGuide = class Guide extends React.Component {
     if (dismissed) {
       soundLibrary.playSound('other');
     }
-  }
+  }x
 
   render() {
     const state = getState();

--- a/src/oceans/components/common/Guide.jsx
+++ b/src/oceans/components/common/Guide.jsx
@@ -1,74 +1,33 @@
 import React from 'react';
-import Radium from "radium";
-import Typist from "react-typist";
+import Radium from 'radium';
+import Typist from 'react-typist';
 
-import "@ml/oceans/styles/fade.css";
+import '@ml/oceans/styles/fade.css';
 
-import {getState, setState} from "@ml/oceans/state";
-import guide from "@ml/oceans/models/guide";
-import soundLibrary from "@ml/oceans/models/soundLibrary";
-import styles from "@ml/oceans/styles";
-import colors from "@ml/oceans/styles/colors";
-import I18n from "@ml/oceans/i18n";
-import {Button} from "@ml/oceans/components/common";
-import arrowDownImage from "@public/images/arrow-down.png";
-import fingerClickIcon1 from "@public/images/finger-click-icon-1.svg";
-import fingerClickIcon2 from "@public/images/finger-click-icon-2.svg";
+import {getState, setState} from '@ml/oceans/state';
+import guide from '@ml/oceans/models/guide';
+import soundLibrary from '@ml/oceans/models/soundLibrary';
+import styles from '@ml/oceans/styles';
+import colors from '@ml/oceans/styles/colors';
+import I18n from '@ml/oceans/i18n';
+import {Button} from '@ml/oceans/components/common';
+import arrowDownImage from '@public/images/arrow-down.png';
+import fingerClickIcon1 from '@public/images/finger-click-icon-1.svg';
+import fingerClickIcon2 from '@public/images/finger-click-icon-2.svg';
 
 let UnwrappedGuide = class Guide extends React.Component {
   onShowing() {
-    clearInterval(getState().guideTypingTimer);
-    setState({guideShowing: true, guideTypingTimer: null});
+    const state = getState();
 
-    // filter out all this other behavior too if not in K5 mode?
-    if (!guide.getCurrentGuide().noDimBackground) {
-      const timerId = setTimeout(() => {
-        setState({showClickToContinue: true});
-        const intervalId = setInterval(() => setState({clickToContinueIconFrame1: !getState().clickToContinueIconFrame1}), 400);
-        setState({clickToContinueAnimationIntervalId: intervalId});
-      }, 2000);
-      setState({clickToContinueTimerId: timerId});
-    }
+    clearInterval(state.guideTypingTimer);
+    setState({guideShowing: true, guideTypingTimer: null});
   }
 
   dismissGuideClick() {
     const dismissed = guide.dismissCurrentGuide();
     if (dismissed) {
       soundLibrary.playSound('other');
-
-      setState({showClickToContinue: false});
-      const {
-        clickToContinueTimerId,
-        clickToContinueAnimationIntervalId
-      } = getState();
-      if (clickToContinueTimerId) {
-        clearTimeout(clickToContinueTimerId);
-        setState({clickToContinueTimerId: null});
-      }
-      if (clickToContinueAnimationIntervalId) {
-        clearInterval(clickToContinueAnimationIntervalId);
-        setState({clickToContinueAnimationIntervalId: null});
-      }
     }
-  }
-
-  renderClickToContinueReminder(currentGuide) {
-    return (
-      getState().guides === 'K5' &&
-      currentGuide.style !== 'Info' &&
-      !currentGuide.noDimBackground && (
-        <div style={styles.guideClickToContinueReminderContainer} className="fade">
-          <img
-            style={getState().clickToContinueIconFrame1 ? styles.guideHideClickToContinueAnimationFrame : {}}
-            src={fingerClickIcon1}
-            alt={'A clicking animation reminding users to click anywhere to continue.'}
-          />
-          <img
-            style={getState().clickToContinueIconFrame1 ? {} : styles.guideHideClickToContinueAnimationFrame}
-            src={fingerClickIcon2}
-          />
-        </div>
-      ))
   }
 
   render() {
@@ -94,6 +53,11 @@ let UnwrappedGuide = class Guide extends React.Component {
       }, 1000 / 10);
       setState({guideTypingTimer});
     }
+
+    const renderClickToContinueReminder =
+      state.guides === 'K5' &&
+      state.guideShowing &&
+      !guide.getCurrentGuide().noDimBackground;
 
     return (
       <div>
@@ -133,8 +97,6 @@ let UnwrappedGuide = class Guide extends React.Component {
                     >
                       {currentGuide.textFn(getState())}
                     </Typist>
-                    {getState().showClickToContinue
-                      && this.renderClickToContinueReminder(currentGuide)}
                   </div>
                   <div
                     style={
@@ -145,14 +107,27 @@ let UnwrappedGuide = class Guide extends React.Component {
                   >
                     <div style={styles.guideFinalText}>
                       {currentGuide.textFn(getState())}
-                      {this.renderClickToContinueReminder(currentGuide)}
                     </div>
                   </div>
-                  {currentGuide.style === 'Info' && (
-                    <Button
-                      style={styles.infoGuideButton} onClick={() => {
-                    }}
+                  {renderClickToContinueReminder && (
+                    <div
+                      id="click-to-continue-reminder"
+                      style={styles.guideClickToContinueReminderContainer}
                     >
+                      <img
+                        src={fingerClickIcon1}
+                        alt=""
+                        style={styles.guideClickToContinueReminder1}
+                      />
+                      <img
+                        src={fingerClickIcon2}
+                        alt=""
+                        style={styles.guideClickToContinueReminder2}
+                      />
+                    </div>
+                  )}
+                  {currentGuide.style === 'Info' && (
+                    <Button style={styles.infoGuideButton} onClick={() => {}}>
                       {I18n.t('continue')}
                     </Button>
                   )}

--- a/src/oceans/components/common/Guide.jsx
+++ b/src/oceans/components/common/Guide.jsx
@@ -26,7 +26,7 @@ let UnwrappedGuide = class Guide extends React.Component {
     if (dismissed) {
       soundLibrary.playSound('other');
     }
-  }x
+  }
 
   render() {
     const state = getState();

--- a/src/oceans/state.js
+++ b/src/oceans/state.js
@@ -38,11 +38,7 @@ const initialState = {
   guideDismissals: [],
   guideShowing: false,
   showConfirmationDialog: false,
-  confirmationDialogOnYes: null,
-  showClickToContinue: false,
-  clickToContinueTimerId: null,
-  clickToContinueAnimationIntervalId: null,
-  clickToContinueIconFrame1: true,
+  confirmationDialogOnYes: null
 };
 let state = {...initialState};
 

--- a/src/oceans/styles/fade.css
+++ b/src/oceans/styles/fade.css
@@ -1,11 +1,17 @@
-.fade {
-  animation: show 600ms 100ms ease-in forwards;
-  opacity: 0;
-}
-
-@keyframes show {
+@keyframes fadein {
+  0% {
+    opacity: 0;
+  }
   100% {
     opacity: 1;
-    transform: none;
+  }
+}
+
+@keyframes blink {
+  0%, 45% {
+    opacity: 0;
+  }
+  55%, 100% {
+    opacity: 1;
   }
 }

--- a/src/oceans/styles/index.js
+++ b/src/oceans/styles/index.js
@@ -1,4 +1,4 @@
-import colors from "@ml/oceans/styles/colors";
+import colors from '@ml/oceans/styles/colors';
 
 const styles = {
   body: {
@@ -508,13 +508,23 @@ const styles = {
     opacity: 0
   },
   guideClickToContinueReminderContainer: {
-    display: 'flex',
-    justifyContent: 'flex-end',
-    height: 30,
-    alignItems: 'end'
+    position: 'absolute',
+    right: '1%',
+    bottom: 0,
+    width: 25,
+    width: '5%',
+    minWidth: 25,
+    height: 15,
+    animation: '0.25s ease-in 3s 1 normal backwards running fadein'
   },
-  guideHideClickToContinueAnimationFrame: {
-    display: 'none'
+  guideClickToContinueReminder1: {
+    width: '100%',
+    position: 'absolute'
+  },
+  guideClickToContinueReminder2: {
+    animation: '1s linear 0.5s infinite normal none running blink',
+    width: '100%',
+    position: 'absolute'
   },
   guideBackground: {
     backgroundColor: 'rgba(0,0,0,0.3)',
@@ -598,4 +608,4 @@ const styles = {
   }
 };
 
-export default styles
+export default styles;

--- a/src/oceans/styles/index.js
+++ b/src/oceans/styles/index.js
@@ -511,7 +511,6 @@ const styles = {
     position: 'absolute',
     right: '1%',
     bottom: 0,
-    width: 25,
     width: '5%',
     minWidth: 25,
     height: 15,


### PR DESCRIPTION
Some potential updates to the Guide's "click to continue" reminder.

- Fade and blinking done with CSS rather than code-based timers.
- Support for 1280px width layout in the standalone runtime, which matches the widest possible render when hosted by dashboard.