### PR TITLE
K5 guides curriculum-specified updates

### DIFF
--- a/i18n/oceans.json
+++ b/i18n/oceans.json
@@ -53,6 +53,7 @@
     "fishlong-pond-init3": "Or you can teach A.I. a new word by choosing New Word.",
     "didYouKnow": "Did you know?",
     "continue": "Continue",
+    "training-generic-please-continue": "Great Work! Click Continue to see what A.I. has learned.",
     "areYouSure": "Are you sure?",
     "eraseWarning": "Erasing A.I.'s data will permanently delete all training. Is that what you want to do?",
     "erase": "Erase",

--- a/src/oceans/models/guidesK5.js
+++ b/src/oceans/models/guidesK5.js
@@ -12,6 +12,9 @@ const imageStyleOverrides = {
   can: {bottom: '2%', left: '16%'}
 };
 
+const encourageStopTrainingCountsFishLong = [150, 200, 250];
+const encourageStopTrainingCountsDefault = [100, ...encourageStopTrainingCountsFishLong];
+
 const guidesK5 = [
   {
     id: "fishvtrash-training-init1",
@@ -43,47 +46,8 @@ const guidesK5 = [
     arrow: "LowerCenter",
   },
   {
-    id: "fishvtrash-training-pause1",
-    textFn: () => I18n.t("fishvtrash-training-pause1"),
-    when: {
-      appMode: AppMode.FishVTrash,
-      currentMode: Modes.Training,
-      fn: (state) => {
-        return state.yesCount + state.noCount >= 5;
-      },
-    },
-    style: "Info",
-    image: trashBottleImage,
-    imageStyle: imageStyleOverrides.bottle,
-  },
-  {
     id: "fishvtrash-training-pause2",
     textFn: () => I18n.t("fishvtrash-training-pause2"),
-    when: {
-      appMode: AppMode.FishVTrash,
-      currentMode: Modes.Training,
-      fn: (state) => {
-        return state.yesCount + state.noCount >= 5;
-      },
-    },
-  },
-  {
-    id: "fishvtrash-training-pause3",
-    textFn: () => I18n.t("fishvtrash-training-pause3"),
-    when: {
-      appMode: AppMode.FishVTrash,
-      currentMode: Modes.Training,
-      fn: (state) => {
-        return state.yesCount + state.noCount >= 15;
-      },
-    },
-    style: "Info",
-    image: trashCanImage,
-    imageStyle: imageStyleOverrides.can,
-  },
-  {
-    id: "fishvtrash-training-pause4",
-    textFn: () => I18n.t("fishvtrash-training-pause4"),
     when: {
       appMode: AppMode.FishVTrash,
       currentMode: Modes.Training,
@@ -99,10 +63,23 @@ const guidesK5 = [
       appMode: AppMode.FishVTrash,
       currentMode: Modes.Training,
       fn: (state) => {
-        return state.yesCount + state.noCount >= 30;
+        return state.yesCount + state.noCount >= 50;
       },
     },
   },
+  ...encourageStopTrainingCountsDefault.map(count => {
+    return {
+      id: `fishvtrash-training-generic-please-continue-count-${count}`,
+      textFn: () => I18n.t('training-generic-please-continue'),
+      when: {
+        appMode: AppMode.FishVTrash,
+        currentMode: Modes.Training,
+        fn: state => {
+          return state.yesCount + state.noCount >= count;
+        }
+      }
+    }
+  }),
   {
     id: "fishvtrash-predicting-init1",
     textFn: () => I18n.t("fishvtrash-predicting-init1"),
@@ -151,7 +128,7 @@ const guidesK5 = [
   },
   {
     id: "creaturesvtrashdemo-predicting-init1",
-    textFn: () => 'This is a test string.',
+    textFn: () => I18n.t("creaturesvtrashdemo-predicting-init1"),
     when: {
       appMode: AppMode.CreaturesVTrashDemo,
       currentMode: Modes.Predicting,
@@ -233,7 +210,7 @@ const guidesK5 = [
       appMode: AppMode.CreaturesVTrash,
       currentMode: Modes.Training,
       fn: (state) => {
-        return state.yesCount + state.noCount >= 5;
+        return state.yesCount + state.noCount >= 15;
       },
     },
     style: "Info",
@@ -243,31 +220,6 @@ const guidesK5 = [
   {
     id: "creaturesvtrash-training-init3",
     textFn: () => I18n.t("creaturesvtrash-training-init3"),
-    when: {
-      appMode: AppMode.CreaturesVTrash,
-      currentMode: Modes.Training,
-      fn: (state) => {
-        return state.yesCount + state.noCount >= 5;
-      },
-    },
-  },
-  {
-    id: "creaturesvtrash-training-init4",
-    textFn: () => I18n.t("creaturesvtrash-training-init4"),
-    when: {
-      appMode: AppMode.CreaturesVTrash,
-      currentMode: Modes.Training,
-      fn: (state) => {
-        return state.yesCount + state.noCount >= 15;
-      },
-    },
-    style: "Info",
-    image: turtleImage,
-    imageStyle: imageStyleOverrides.turtle,
-  },
-  {
-    id: "creaturesvtrash-training-init5",
-    textFn: () => I18n.t("creaturesvtrash-training-init5"),
     when: {
       appMode: AppMode.CreaturesVTrash,
       currentMode: Modes.Training,
@@ -283,10 +235,23 @@ const guidesK5 = [
       appMode: AppMode.CreaturesVTrash,
       currentMode: Modes.Training,
       fn: (state) => {
-        return state.yesCount + state.noCount >= 30;
+        return state.yesCount + state.noCount >= 50;
       },
     },
   },
+  ...encourageStopTrainingCountsDefault.map(count => {
+    return {
+      id: `creaturesvtrash-training-generic-please-continue-count-${count}`,
+      textFn: () => I18n.t('training-generic-please-continue'),
+      when: {
+        appMode: AppMode.CreaturesVTrash,
+        currentMode: Modes.Training,
+        fn: state => {
+          return state.yesCount + state.noCount >= count;
+        }
+      }
+    }
+  }),
   {
     id: "creaturesvtrash-predicting-init1",
     textFn: () => I18n.t("creaturesvtrash-predicting-init1"),
@@ -426,6 +391,19 @@ const guidesK5 = [
       },
     },
   },
+  ...encourageStopTrainingCountsFishLong.map(count => {
+    return {
+      id: `fishlong-training-generic-please-continue-count-${count}`,
+      textFn: () => I18n.t('training-generic-please-continue'),
+      when: {
+        appMode: AppMode.FishLong,
+        currentMode: Modes.Training,
+        fn: state => {
+          return state.yesCount + state.noCount >= count;
+        }
+      }
+    }
+  }),
   {
     id: "fishlong-training-many",
     textFn: () => I18n.t("fishlong-training-many"),

--- a/src/oceans/models/guidesK5.js
+++ b/src/oceans/models/guidesK5.js
@@ -1,8 +1,5 @@
 import {AppMode, Modes} from '../constants';
-import turtleImage from '@public/images/turtle-large.png';
 import seahorseImage from '@public/images/seahorse-large.png';
-import trashBottleImage from '@public/images/bottle-large.png';
-import trashCanImage from '@public/images/can-large.png';
 import I18n from '../i18n';
 
 const imageStyleOverrides = {


### PR DESCRIPTION
Makes changes to the "guides" presented in the new K5 version of this progression, which are generally:
- removing some "Did you know?" guides.
- add more reminders to suggest that users stop training once they've categorized a large number of fish/sea creatures.

The details of the changes requested are in [this doc](https://docs.google.com/document/d/1szxMX1deW-gBYJa3xigPDgVvgrMw3hEJ-scqr-bBigo/edit). Note that the `FishShort` app mode (which is used on [this level in the Hour of Code script](https://studio.code.org/s/oceans/lessons/1/levels/6)) is not used in the current K5 AI unit, so no changes are made there.

## Testing story

I ran through each of the affected levels and compared the guides I saw to the expected behavior on the doc linked above.

## Follow-up work

We'll need to hook this up to level config such that the right version of the guides file (`guidesK5`) is used in the K5 AI unit.